### PR TITLE
Make packing rules static and tied to a project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,12 @@ migrate:
 	migrate -database $(DB_URI)?sslmode=disable -path $(MIGRATE_DIR) up
 
 migrate-create:
+ifndef name
+	$(error name variable must be set)
+else
 	mkdir -p $(MIGRATE_DIR)
 	migrate create -ext sql -dir $(MIGRATE_DIR) -seq $(name)
+endif
 
 internal/pb/%.pb.go: internal/pb/%.proto
 	protoc --experimental_allow_proto3_optional --go_out=. --go_opt=paths=source_relative $^

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -164,45 +164,6 @@ func (a *updateArgs) run(ctx context.Context, log *zap.Logger, c *client.Client)
 	log.Info("updated objects", zap.Int64("project", a.project), zap.Int64("version", version), zap.Int("count", count))
 }
 
-type packArgs struct {
-	server  string
-	project int64
-	path    string
-}
-
-func parsePackArgs(log *zap.Logger, args []string) *packArgs {
-	set := flag.NewFlagSet("update", flag.ExitOnError)
-
-	server := set.String("server", "", "Server GRPC address")
-	project := set.Int64("project", -1, "Project ID (required)")
-	path := set.String("path", "", "Root of the object path to pack")
-
-	set.Parse(args)
-
-	if *project == -1 {
-		log.Fatal("-project required")
-	}
-
-	return &packArgs{
-		server:  *server,
-		project: *project,
-		path:    *path,
-	}
-}
-
-func (a *packArgs) serverAddr() string {
-	return a.server
-}
-
-func (a *packArgs) run(ctx context.Context, log *zap.Logger, c *client.Client) {
-	version, err := c.Pack(ctx, a.project, a.path)
-	if err != nil {
-		log.Fatal("pack objects", zap.Int64("project", a.project), zap.String("path", a.path), zap.Error(err))
-	}
-
-	log.Info("packed objects", zap.Int64("project", a.project), zap.String("path", a.path), zap.Int64("version", version))
-}
-
 type inspectArgs struct {
 	server  string
 	project int64
@@ -324,8 +285,6 @@ func main() {
 		cmd = parseRebuildArgs(log, os.Args[2:])
 	case "update":
 		cmd = parseUpdateArgs(log, os.Args[2:])
-	case "pack":
-		cmd = parsePackArgs(log, os.Args[2:])
 	case "inspect":
 		cmd = parseInspectArgs(log, os.Args[2:])
 	case "snapshot":

--- a/internal/db/copy.go
+++ b/internal/db/copy.go
@@ -8,17 +8,17 @@ import (
 )
 
 func CopyAllObjects(ctx context.Context, tx pgx.Tx, source int64, target int64) error {
-	var samePackPaths bool
+	var samePackPatterns bool
 	err := tx.QueryRow(ctx, `
-		SELECT COALESCE((SELECT pack_paths FROM dl.projects WHERE id = $1), '{}') =
-		       COALESCE((SELECT pack_paths FROM dl.projects WHERE id = $2), '{}');
-	`, source, target).Scan(&samePackPaths)
+		SELECT COALESCE((SELECT pack_patterns FROM dl.projects WHERE id = $1), '{}') =
+		       COALESCE((SELECT pack_patterns FROM dl.projects WHERE id = $2), '{}');
+	`, source, target).Scan(&samePackPatterns)
 	if err != nil {
-		return fmt.Errorf("check matching pack paths, source %v, target %v: %w", source, target, err)
+		return fmt.Errorf("check matching pack patterns, source %v, target %v: %w", source, target, err)
 	}
 
-	if !samePackPaths {
-		return fmt.Errorf("cannot copy paths because pack paths do not match for source %v and target %v", source, target)
+	if !samePackPatterns {
+		return fmt.Errorf("cannot copy paths because pack patterns do not match for source %v and target %v", source, target)
 	}
 
 	_, err = tx.Exec(ctx, `

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -8,13 +8,13 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-func CreateProject(ctx context.Context, tx pgx.Tx, project int64) error {
+func CreateProject(ctx context.Context, tx pgx.Tx, project int64, packPaths []string) error {
 	_, err := tx.Exec(ctx, `
-		INSERT INTO dl.projects (id, latest_version)
-		VALUES ($1, 0)
-	`, project)
+		INSERT INTO dl.projects (id, latest_version, pack_paths)
+		VALUES ($1, 0, $2)
+	`, project, packPaths)
 	if err != nil {
-		return fmt.Errorf("create project %v: %w", project, err)
+		return fmt.Errorf("create project %v, packPatterns %v: %w", project, packPaths, err)
 	}
 
 	return nil

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -8,13 +8,13 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-func CreateProject(ctx context.Context, tx pgx.Tx, project int64, packPaths []string) error {
+func CreateProject(ctx context.Context, tx pgx.Tx, project int64, packPatterns []string) error {
 	_, err := tx.Exec(ctx, `
-		INSERT INTO dl.projects (id, latest_version, pack_paths)
+		INSERT INTO dl.projects (id, latest_version, pack_patterns)
 		VALUES ($1, 0, $2)
-	`, project, packPaths)
+	`, project, packPatterns)
 	if err != nil {
-		return fmt.Errorf("create project %v, packPatterns %v: %w", project, packPaths, err)
+		return fmt.Errorf("create project %v, packPatterns %v: %w", project, packPatterns, err)
 	}
 
 	return nil

--- a/internal/pb/fs.proto
+++ b/internal/pb/fs.proto
@@ -15,8 +15,6 @@ service Fs {
 
     rpc Update(stream UpdateRequest) returns (UpdateResponse);
 
-    rpc Pack(PackRequest) returns (PackResponse);
-
     rpc Inspect(InspectRequest) returns (InspectResponse);
 
     rpc Snapshot(SnapshotRequest) returns (SnapshotResponse);
@@ -27,6 +25,7 @@ service Fs {
 message NewProjectRequest {
     int64 id = 1;
     optional int64 template = 2;
+    repeated string pack_paths = 3;
 }
 
 message NewProjectResponse {};
@@ -92,15 +91,6 @@ message UpdateRequest {
 }
 
 message UpdateResponse {
-    int64 version = 1;
-}
-
-message PackRequest {
-    int64 project = 1;
-    string path = 2;
-}
-
-message PackResponse {
     int64 version = 1;
 }
 

--- a/internal/pb/fs.proto
+++ b/internal/pb/fs.proto
@@ -25,7 +25,7 @@ service Fs {
 message NewProjectRequest {
     int64 id = 1;
     optional int64 template = 2;
-    repeated string pack_paths = 3;
+    repeated string pack_patterns = 3;
 }
 
 message NewProjectResponse {};

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -30,11 +30,13 @@ class UpdateInputStream {
   }
 }
 
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
 /**
  * Encode string object contents as an array of bytes.
  */
 export function encodeContent(content: string): Uint8Array {
-  const encoder = new TextEncoder();
   return encoder.encode(content);
 }
 
@@ -42,7 +44,6 @@ export function encodeContent(content: string): Uint8Array {
  * Decode an array of bytes as an object's string contents.
  */
  export function decodeContent(bytes: Uint8Array | undefined): string {
-  const decoder = new TextDecoder();
   return decoder.decode(bytes);
 }
 
@@ -76,9 +77,9 @@ export class DateiLagerClient {
     };
   }
 
-  async newProject(project: bigint, packPaths: string[], template?: bigint) {
+  async newProject(project: bigint, packPatterns: string[], template?: bigint) {
     await this.client.newProject(
-      { id: project, packPaths: packPaths, template: template },
+      { id: project, packPatterns: packPatterns, template: template },
       this._options()
     );
   }

--- a/migrations/000002_pack_patterns.down.sql
+++ b/migrations/000002_pack_patterns.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dl.projects
+DROP COLUMN pack_paths;

--- a/migrations/000002_pack_patterns.down.sql
+++ b/migrations/000002_pack_patterns.down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE dl.projects
-DROP COLUMN pack_paths;
+DROP COLUMN pack_patterns;

--- a/migrations/000002_pack_patterns.up.sql
+++ b/migrations/000002_pack_patterns.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dl.projects
+ADD COLUMN pack_paths text[];

--- a/migrations/000002_pack_patterns.up.sql
+++ b/migrations/000002_pack_patterns.up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE dl.projects
-ADD COLUMN pack_paths text[];
+ADD COLUMN pack_patterns text[];

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -233,19 +233,6 @@ func (c *Client) Update(ctx context.Context, project int64, diffPath string, dir
 	return response.Version, len(diff.Updates), nil
 }
 
-func (c *Client) Pack(ctx context.Context, project int64, path string) (int64, error) {
-	response, err := c.fs.Pack(ctx, &pb.PackRequest{
-		Project: project,
-		Path:    path,
-	})
-
-	if err != nil {
-		return -1, fmt.Errorf("pack path %v in project %v: %w", path, project, err)
-	}
-
-	return response.Version, nil
-}
-
 func (c *Client) Inspect(ctx context.Context, project int64) (*pb.InspectResponse, error) {
 	inspect, err := c.fs.Inspect(ctx, &pb.InspectRequest{Project: project})
 	if err != nil {


### PR DESCRIPTION
Instead of dynamic pack rules using an endpoint, it seems far more likely that packing rules will be static for a project.

This simpler way of managing packing rules requires them when building a new project.

This needs to be updated to support patterns instead of just a fixed prefix.