### PR TITLE
Remove dev cert from release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
 
+    - run: go mod download
+    - run: make install
+    - run: make internal/pb/fs.pb.go internal/pb/fs_grpc.pb.go js/src/fs.client.ts
+
     - uses: goreleaser/goreleaser-action@v2
       with:
         version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,3 @@
-before:
-  hooks:
-    - go mod download
-    - make install
-    - make internal/pb/fs.pb.go internal/pb/fs_grpc.pb.go dev/server.cert js/src/fs.client.ts
-
 builds:
   - main: ./cmd/client/main.go
     id: client


### PR DESCRIPTION
Builds the protoc and js client required for release. Also moves logic
outside of goreleaser itself, and into the action.
