### PR TITLE
Buffer GetCompress and parallelize rebuild in client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 input/
 input_old/
 rebuild/
+output/
 release/
 *.prof
 *.pb.go

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -186,7 +186,7 @@ func (a *rebuildArgs) run(ctx context.Context, log *zap.Logger, c *client.Client
 	if version == -1 {
 		log.Debug("latest version already checked out", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64("version", *a.vrange.From))
 	} else {
-		log.Info("wrote files", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64("version", version), zap.Int("diff_count", count))
+		log.Info("wrote files", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64("version", version), zap.Uint32("diff_count", count))
 	}
 
 	fmt.Println(version)
@@ -234,7 +234,7 @@ func (a *updateArgs) run(ctx context.Context, log *zap.Logger, c *client.Client)
 			log.Fatal("update objects", zap.Error(err))
 		}
 
-		log.Info("updated objects", zap.Int64("project", a.project), zap.Int64("version", version), zap.Int("count", count))
+		log.Info("updated objects", zap.Int64("project", a.project), zap.Int64("version", version), zap.Uint32("count", count))
 		fmt.Println(version)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	google.golang.org/genproto v0.0.0-20210518161634-ec7691c0a37d // indirect
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -130,6 +130,7 @@ func (s *Server) monitorDbPool(ctx context.Context, dbConn *DbPoolConnector) {
 			select {
 			case <-ctx.Done():
 				s.Health.SetServingStatus("dateilager.server", healthpb.HealthCheckResponse_NOT_SERVING)
+				return
 			case <-ticker.C:
 				ctxTimeout, cancel := context.WithTimeout(ctx, 800*time.Millisecond)
 

--- a/scripts/complex_input.sh
+++ b/scripts/complex_input.sh
@@ -18,16 +18,14 @@ readonly INPUT_DIR="${ROOT_DIR}/input"
 build_node_modules() {
     local package_json="${1}"
     local output="${2}"
-    local tmpdir="$(mktemp -d -t dl-XXXXXXXXXX)"
 
-    cp "${package_json}" "${tmpdir}/package.json"
+    mkdir -p "${output}/node_modules"
+
+    cp "${package_json}" "${output}/package.json"
     (
-        cd "${tmpdir}"
+        cd "${output}"
         npm install &> /dev/null
-        cp -r ./node_modules/* "${output}"
     )
-
-    rm -rf "${tmpdir:?}"
 }
 
 v1() {


### PR DESCRIPTION
When a client needs to execute a rebuild (update an on disk file system from version X to Y) it requests all of these updates as a stream of TAR files.

In the previous implementation, we serially read a TAR file from the stream, decompress it's contents and walked each object writing it to disk. In the situation where writes to disk are slower than the reads from the API, this keeps the read stream and Postgres query open longer than they need to be.

In contrast, this version reads the stream of TAR files into a buffered channel and starts 4 go routines to work off of this channel writing files to disk in parallel.

The two tunables this introduces are:

- How many TAR files should we buffer on the client. We are trading off memory usage at the cost of keeping the API & Postgres query open.
- How many goroutines should we launch to in order to saturate disk write IO.

I picked numbers based on quick local testing, but that's not representative of production use.

-------

One more piece of context, the number of TAR files returned by the `GetCompress` API is roughly: `len(node_modules) + size(source_files) / 512KB`.

When a `GetCompress` query is made we do not repack any already packed objects and in Gadget's case every node module is packed.

For all remaining files, source files and Gadget generated files, we pack them on the fly into TAR files and very roughly aim for 512KB files.