### PR TITLE
Warning cleanup

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -74,6 +74,9 @@ func NewClient(ctx context.Context, server, token string) (*Client, error) {
 }
 
 func (c *Client) Close() {
+	// Give a chance for the upstream socket to finish writing it's response
+	// https://github.com/grpc/grpc-go/issues/2869#issuecomment-503310136
+	time.Sleep(1 * time.Millisecond)
 	c.conn.Close()
 }
 
@@ -105,7 +108,6 @@ func (c *Client) DeleteProject(ctx context.Context, project int64) error {
 	_, err := c.fs.DeleteProject(ctx, &pb.DeleteProjectRequest{
 		Project: project,
 	})
-
 	if err != nil {
 		return fmt.Errorf("delete project: %w", err)
 	}


### PR DESCRIPTION
Two small changes to help debug DL.

1. Stop using `%w` with GRPC's `status.Errorf`, while error wrapping is supported by `fmt.Errorf` it is not supported by GRPC. This makes real errors much harder to parse and debug.
 
2. Following the investigation into the client closing sockets too early, attempt to wait for them to wrap up. `1ms` stopped all of the warnings locally, not sure about CI or prod though.