### PR TITLE
Nixify development environment

### DIFF
--- a/.development/nix/scripts/clean.nix
+++ b/.development/nix/scripts/clean.nix
@@ -1,0 +1,23 @@
+{ lib
+, writeShellScriptBin
+, git
+}:
+
+let
+  keepFiles = [
+    # Local-specific files
+    ".envrc.local"
+    ".vscode"
+    "TODO"
+
+    # Cache files
+    "node_modules" # Has no functional effect on `dev` service since new/updated modules will be fetched when needed
+  ];
+in
+writeShellScriptBin "clean" ''
+  ${git}/bin/git clean -xdf ${lib.concatStringsSep " " (builtins.map (file: "-e ${file}") keepFiles)}
+'' // {
+  meta = {
+    description = "Reset DateiLager back to a clean state as if it was cloned for the first time";
+  };
+}

--- a/.development/nix/scripts/dev.nix
+++ b/.development/nix/scripts/dev.nix
@@ -1,0 +1,60 @@
+{ lib
+, ansifilter
+, coreutils
+, moreutils
+, services
+, writeShellScriptBin
+}:
+
+let
+  packages = lib.unique ([
+    ansifilter
+    coreutils
+    moreutils
+  ] ++ builtins.concatMap (service: service.packages or []) services);
+
+  compileService = isLast: service:
+    let
+      colorize = text:
+        "$'\\e[1;${service.ansiColor or ""}m${text}\\e[0m'";
+
+      consoleFilter = lib.optionalString (service ? consoleFilter)
+        "| grep -v ${service.consoleFilter}";
+    in
+      builtins.concatStringsSep "\n" ([]
+        ++ lib.optional (service ? env) service.env
+        ++ lib.optional (service ? setup) ''
+          (${service.setup}) 2>&1 | \
+            ts ${colorize "${service.name} (setup)>"}
+        ''
+        ++ lib.optional (service ? run) ''
+          (${service.run}) 2>&1 | pee \
+            "ts ${colorize "${service.name}>"}${consoleFilter}" \
+            'ansifilter > tmp/log/${service.name}.log'${lib.optionalString (!isLast) " &"}
+        ''
+        ++ lib.optional (!(service ? run) && isLast) ''
+          sleep infinity
+        '');
+
+  compileServices = services:
+    builtins.concatStringsSep "\n"
+      (lib.imap0
+        (i: service:
+          compileService (i == builtins.length services - 1) service)
+        services);
+in
+writeShellScriptBin "dev" ''
+  set -e
+  export PATH=${lib.makeBinPath packages}:$PATH
+
+  # Stop all services when Ctrl-C is pressed or error occurs
+  trap 'kill $(jobs -p) 2>/dev/null; wait $(jobs -p)' INT TERM ERR EXIT
+
+  mkdir -p tmp/log
+
+  ${compileServices services}
+'' // {
+  meta = with lib; {
+    description = "Runs all the services necessary for DateiLager development";
+  };
+}

--- a/.development/nix/services/default.nix
+++ b/.development/nix/services/default.nix
@@ -1,0 +1,8 @@
+{ lib
+, callPackage
+}:
+
+[
+  (callPackage ./postgres.nix { })
+  (callPackage ./setup-db.nix { })
+]

--- a/.development/nix/services/postgres.nix
+++ b/.development/nix/services/postgres.nix
@@ -1,0 +1,51 @@
+{ coreutils
+, postgresql
+}:
+
+{
+  name = "postgres";
+  ansiColor = "34";
+
+  packages = [
+    coreutils # sleep
+    postgresql
+  ];
+
+  env = ''
+    export PGDATA="$PWD/tmp/postgres"
+    export PGUSER=postgres
+    export PGPASSWORD=password
+    export PGURI="postgres://$PGUSER:$PGPASSWORD@127.0.0.1"
+
+    wait_for_postgres() {
+      until psql "$PGURI/postgres" -c '\q' 2> /dev/null; do
+        sleep 0.2
+      done
+    }
+
+    database_exists() {
+      if [ "$(psql "$PGURI/postgres" -qtAc "SELECT 1 FROM pg_database WHERE datname = '$1'")" == "1" ]; then
+        exit 0
+      else
+        exit 1
+      fi
+    }
+
+    create_database() {
+      psql "$PGURI/postgres" -c "CREATE DATABASE $dbname;"
+    }
+  '';
+
+  setup = ''
+    if [ ! -d "$PGDATA" ]; then
+      echo "== Creating postgres database cluster =="
+      initdb --username="$PGUSER" --pwfile=<(echo "$PGPASSWORD")
+    fi
+  '';
+
+  # Don't try to create a unix socket
+  # We only use TCP sockets and some systems require root permissions for unix sockets
+  run = ''
+    postgres -c unix_socket_directories= -c timezone=UTC -c fsync=off -c synchronous_commit=off -c full_page_writes=off
+  '';
+}

--- a/.development/nix/services/setup-db.nix
+++ b/.development/nix/services/setup-db.nix
@@ -1,0 +1,17 @@
+{}:
+
+{
+  name = "setup-db";
+  ansiColor = "36";
+
+  setup = ''
+    wait_for_postgres
+
+    for dbname in dl dl_tests; do
+      if ! $(database_exists $dbname); then
+        echo "== Creating '$dbname' database =="
+        create_database $dbname
+      fi
+    done
+  '';
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+
+source_env_if_exists .envrc.local

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,51 @@
+name: 'Set up environment'
+description: ''
+inputs: {}
+outputs: {}
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@v14
+      with:
+        install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
+        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+
+    - run: nix flake check
+      shell: bash
+
+    - name: Set cache paths
+      id: cache-paths
+      run: |
+        echo "::set-output name=go_mod::$(go env GOMODCACHE)"
+        echo "::set-output name=go_build::$(go env GOCACHE)"
+        echo "::set-output name=npm::$(npm config get cache)"
+      shell: nix develop -c bash -eo pipefail -l {0}
+
+    - name: Cache go mods
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.cache-paths.outputs.go_mod }}
+          ${{ steps.cache-paths.outputs.go_build }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Cache npm packages
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.cache-paths.outputs.npm }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - run: go mod download
+      shell: nix develop -c bash -eo pipefail -l {0}
+
+    - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      shell: nix develop -c bash -eo pipefail -l {0}
+
+    - run: make install
+      shell: nix develop -c bash -eo pipefail -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,40 +6,15 @@ on:
       - v*
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
   build:
+    needs: test
     runs-on: ubuntu-20.04
-
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 16
-    - uses: arduino/setup-protoc@v1
-
-    - name: Cache go mods
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Cache npm packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
-    - run: go mod download
-    - run: make install
-    - run: make internal/pb/fs.pb.go internal/pb/fs_grpc.pb.go js/src/fs.client.ts
-
+    - uses: ./.github/actions/setup-env
+    - run: nix develop -c make internal/pb/fs.pb.go internal/pb/fs_grpc.pb.go js/src/fs.client.ts
     - uses: goreleaser/goreleaser-action@v2
       with:
         version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,62 +2,14 @@ name: Test
 
 on:
   push:
+  workflow_call:
 
 jobs:
-  build:
-    # Multi OS builds will require nix for Postgres
+  test:
     runs-on: ubuntu-20.04
-
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: "password"
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 16
-    - uses: arduino/setup-protoc@v1
-
-    - name: Cache go mods
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Cache npm packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: go mod download
-
-    - name: Install mkcert
-      run: |
-        sudo apt-get update && sudo apt-get install libnss3-tools
-        curl -o /usr/local/bin/mkcert -L 'https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64'
-        chmod +x /usr/local/bin/mkcert
-        mkcert -install
-    - run: make install
-
-    - run: make build
-    - run: make DB_URI=$DB_URI test
-      env:
-        DB_URI: postgres://postgres:password@localhost:5432/postgres
+    - uses: ./.github/actions/setup-env
+    - run: nix develop -c dev &
+    - run: nix develop -c make build
+    - run: nix develop -c make test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ release/
 *.pb.go
 fs*.ts
 **/node_modules/
+tmp/*
+!tmp/.gitkeep
+.direnv
+.idea/
+.DS_STORE
+.envrc.local

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 	go install github.com/grpc-ecosystem/grpc-health-probe@v0.4
 	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.14
 	go install github.com/bojand/ghz/cmd/ghz@v0.105.0
-	go install github.com/gadget-inc/fsdiff/cmd/fsdiff@v0.1
+	go install github.com/gadget-inc/fsdiff/cmd/fsdiff@v0.4
 	cd js && npm install
 
 migrate:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ PROJECT := dateilager
 
 DB_HOST ?= 127.0.0.1
 DB_USER ?= postgres
-DB_URI := postgres://$(DB_USER)@$(DB_HOST):5432/dl
+DB_PASS ?= password
+DB_URI := postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/dl
 
 GRPC_PORT ?= 5051
 GRPC_SERVER ?= localhost:$(GRPC_PORT)
@@ -81,7 +82,7 @@ release: release/client_linux_amd64 release/client_macos_amd64 release/client_ma
 release: release/webui_linux_amd64 release/webui_macos_amd64 release/webui_macos_arm64
 release: release/assets.tar.gz release/migrations.tar.gz
 
-test: export DB_URI = postgres://$(DB_USER)@$(DB_HOST):5432/dl_tests
+test: export DB_URI = postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/dl_tests
 test: migrate
 	cd test && go test
 

--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,14 @@ server-profile:
 	go run cmd/server/main.go -dburi $(DB_URI) -port $(GRPC_PORT) -prof cpu.prof -log info
 
 client-update: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+client-update: export DL_SKIP_SSL_VERIFICATION=1
 client-update:
 	go run cmd/client/main.go update -project 1 -server $(GRPC_SERVER) -diff input/v1_state/diff.s2 -directory input/v1
 	go run cmd/client/main.go update -project 1 -server $(GRPC_SERVER) -diff input/v2_state/diff.s2 -directory input/v2
 	go run cmd/client/main.go update -project 1 -server $(GRPC_SERVER) -diff input/v3_state/diff.s2 -directory input/v3
 
 client-get: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+client-get: export DL_SKIP_SSL_VERIFICATION=1
 client-get:
 ifndef version
 	go run cmd/client/main.go get -project 1 -server $(GRPC_SERVER) -prefix "$(prefix)"
@@ -116,6 +118,7 @@ else
 endif
 
 client-rebuild: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+client-rebuild: export DL_SKIP_SSL_VERIFICATION=1
 client-rebuild:
 ifndef version
 	go run cmd/client/main.go rebuild -project 1 -server $(GRPC_SERVER) -prefix "$(prefix)" -output $(output)

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ $ make build
 ## API Testing
 
 Ensure there is a Postgres database named `dl_tests`. These tests will write to a real database instance
-but all writes will be rolled back as every test runs within it's own transaction.
+but all writes will be rolled back as every test runs within its own transaction.
 
 ```bash
 $ make test
@@ -136,7 +136,7 @@ console.log("[updateObject] version: " + version);
 
 New versions are released and hosted on Github. (https://github.com/gadget-inc/dateilager/releases)
 
-Create a new tag and push it to Github, Goreleaser will handle building it.
+Create a new tag and push it to GitHub, GoReleaser will handle building it.
 
 ```bash
 $ git tag v0.0.x
@@ -153,7 +153,7 @@ $ make upload-container-image version=0.0.x
 
 The K8S tools assume a local K8S install using Containerd and Podman.
 
-### Requriements
+### Requirements
 
 - docker
 - kubectl
@@ -169,7 +169,7 @@ $ make k8s
 
 ### Client
 
-Execute the client locally and have it connect to a server in K8S. All of the same `client-*` make commands are supported
+Execute the client locally and have it connect to a server in K8S. All the same `client-*` make commands are supported,
 but they require a `k8s-` prefix.
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,8 @@ You can read more about DateiLager's design in the `docs/` directory. A good pla
 
 - Go 1.16
 - Postgresql
-- Node v15
+- Node v16
+- mkcert (https://github.com/FiloSottile/mkcert)
 - Protobuf Compiler (https://grpc.io/docs/protoc-installation/)
 
 Create a Postgres database named `dl`. The default Postgres host is `127.0.0.1` you can override it by

--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ $ make client-get
 You can also filter the results with a prefix search.
 
 ```bash
-$ make client-get prefix=/a
+$ make client-get prefix=n1
 ```
 
 Or filter for a specific version.
@@ -94,7 +94,7 @@ If you want to rebuild an entire project's directory locally, use the `rebuild` 
 
 ```bash
 $ mkdir ./rebuild
-$ make client-rebuild version=3 prefix=/ output=rebuild
+$ make client-rebuild version=3 prefix=n1 output=rebuild
 ```
 
 ## Javascript Client

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -184,7 +184,7 @@ func (a *rebuildArgs) run(ctx context.Context, log *zap.Logger, c *client.Client
 	}
 
 	if version == -1 {
-		log.Debug("latest version already checked out", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64("version", *a.vrange.From))
+		log.Debug("latest version already checked out", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64p("version", a.vrange.From))
 	} else {
 		log.Info("wrote files", zap.Int64("project", a.project), zap.String("output", a.output), zap.Int64("version", version), zap.Uint32("diff_count", count))
 	}
@@ -380,7 +380,7 @@ func main() {
 
 	c, err := client.NewClient(ctx, *shared.server, token)
 	if err != nil {
-		log.Fatal("could not connect to server", zap.String("server", *shared.server), zap.Error(err))
+		log.Fatal("could not connect to server", zap.Stringp("server", shared.server), zap.Error(err))
 	}
 	defer c.Close()
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -22,13 +22,13 @@ After an object is updated, the API will receive a new version for the project. 
 
 ### App Pod Filesystem Snapshots
 
-When a pod is spun up to serve a user's app, it will need to get a snapshot of the latest view of the filesystem. DateiLager's included client can be used to rebuild the filesystem state into a local ephmeral drive.
+When a pod is spun up to serve a user's app, it will need to get a snapshot of the latest view of the filesystem. DateiLager's included client can be used to rebuild the filesystem state into a local ephemeral drive.
 
-Web requests made to this app will run the code available on this ephmeral drive.
+Web requests made to this app will run the code available on this ephemeral drive.
 
 When an update is made within Gadget's web UI, it is Gadget's responsibility to tell all active App pods to update their filesystem state to the latest version.
 
-The included client can be used to apply all updates between it's current filesystem version and the new version sent via Gadget's update mechanism.
+The included client can be used to apply all updates between its current filesystem version and the new version sent via Gadget's update mechanism.
 
 ### Job Pod Batch Updates
 
@@ -48,11 +48,11 @@ There are 3 main models within DateiLager, which align with the 3 database table
 
 A project encapsulates 1 filesystem and all the different versions of that filesystem over time. In Gadget there is a 1 to 1 relationship between a user's environment and a project.
 
-The only details currently tracked about a project in DateiLager are: an ID and it's latest version ID.
+The only details currently tracked about a project in DateiLager are: an ID and its latest version ID.
 
 ### Objects
 
-Objects are the most important model within DateiLager and they can represent 1 of 4 different things:
+Objects are the most important model within DateiLager, and they can represent 1 of 4 different things:
 
 1. A regular file
 2. A symlink
@@ -81,7 +81,7 @@ In order to keep the data within Postgres manageable, Gadget can choose to `Pack
 
 To manage packing rules, when creating a new project you can include a list of pack patterns, these regexes will be used to decide if a path is packed or not.
 
-When updates are made to a packed object, it is decompressed on the fly, the updates are applied and it is then recompressed. This trades off read and write performance to these individual objects to offer a large reduction in total rows within Postgres.
+When updates are made to a packed object, it is decompressed on the fly, the updates are applied, and it is then recompressed. This trades off read and write performance to these individual objects to offer a large reduction in total rows within Postgres.
 
 ## Filesystem Rebuilds
 
@@ -93,8 +93,8 @@ DateiLager will build these compressed TAR files on the fly, but if any objects 
 
 ## Incremental Updates
 
-Once an App pod is up and running, it may receive a notification from Gadget that it should update it's filesystem to a new version.
+Once an App pod is up and running, it may receive a notification from Gadget that it should update its filesystem to a new version.
 
-To avoid rebuilding it's filesystem from scratch, all updates can be done incrementally. This allows it to request only what has changed from it's version to the one it was notified about.
+To avoid rebuilding its filesystem from scratch, all updates can be done incrementally. This allows it to request only what has changed from its version to the one it was notified about.
 
 In a typical use case, this will often mean just a small handful of objects need to be updated on disk.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1648097358,
+        "narHash": "sha256-GMoTKP/po2Nbkh1tvPvP8Ww6NyFW8FFst1Z3nfzffZc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d60081494259c0785f7e228518fee74e0792c1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "DateiLager development environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    (flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (system: nixpkgs.lib.fix (flake:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          callPackage = pkgs.newScope (flake.packages // { inherit callPackage; });
+          services = callPackage ./.development/nix/services { };
+        in
+        rec {
+          packages = rec {
+            ## DateiLager development scripts
+
+            clean = callPackage ./.development/nix/scripts/clean.nix { };
+
+            dev = callPackage ./.development/nix/scripts/dev.nix {
+              inherit services;
+            };
+
+            ## Packages from nixpkgs
+
+            mkcert = pkgs.mkcert;
+
+            go = pkgs.go;
+
+            git = pkgs.git;
+
+            nodejs = pkgs.nodejs-16_x;
+
+            protobuf = pkgs.protobuf;
+
+            postgresql = pkgs.postgresql_13;
+          };
+
+          devShell = pkgs.mkShell {
+            packages = builtins.attrValues self.packages.${system};
+            shellHook = ''
+              GOROOT=${pkgs.go}/share/go
+            '';
+          };
+        }
+      )));
+}


### PR DESCRIPTION
### Nixify our development environment.

I copied/tweaked most of the nix files from gadget mainline so most of these files should look familiar.

The following packages are now managed by nix

- make
- go
- mkcert
- git
- node
- yarn
- postgres
-  protoc

We can now run `dev` and a local postgres instance will spin up on the default port plus the `dl` and `dl_tests` databases will get created (if they don't already exist).

I skipped the following packages from being managed by nix since they're currently installed with go via our makefile. However, if you think any of them should be managed by nix, let me know.

- protoc-gen-go
- protoc-gen-go-grpc
- grpc-health-probe
- golang-migrate
- ghz
- fsdiff

### Other commits

[Use pointer version for zap fields](https://github.com/gadget-inc/dateilager/commit/b0c5522d8554cbcc9516679ca19c533ec5447ffc)
I changed this because I was running into null pointer exceptions while testing the `client-rebuild` command.

[Updated make installed fsdiff to v0.4](https://github.com/gadget-inc/dateilager/commit/afe290d825e332e5055cf560fa0c54e3c2bcc7e2)
Wrong version (self explanatory)

[Added DB_PASS to Makefile](https://github.com/gadget-inc/dateilager/commit/c5a785af3c06319ec876b800240c0ab0aa47b137)
Our nix postgres user needs a password to connect.

[Added DL_SKIP_SSL_VERIFICATION=1 client-* commands](https://github.com/gadget-inc/dateilager/commit/e87132c6d813f93d469808d4412366a567f3a5d1)
All these commands were failing for me without this flag (running `mkcert -install` didn't help). I noticed gadget mainline turns this flag on as well so I copied it here.

[Fixed typos/grammar](https://github.com/gadget-inc/dateilager/commit/4c79b0739627c2a7ed375f4256972b644d1f2d56)
My IDE found and fixed these.

[Updated README requirements](https://github.com/gadget-inc/dateilager/commit/61ac4e963b3db0adf472e4eae67b3b21a90b4bcb)
It [looks like](https://github.com/gadget-inc/dateilager/blob/main/js/.nvmrc) we use Node v16 and we need mkcert.

[Updated examples to show non-empty responses](https://github.com/gadget-inc/dateilager/commit/60264f2eddce9bce331e9ed892dc33d53b609e5e)
The example prefixes didn't return any results or write anything to disk which confused me. I noticed if I used `n1` as a prefix both commands behaved how I would expect.