### PR TITLE
Skip existing identical objects

### DIFF
--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -45,7 +45,6 @@ func DeleteObjects(ctx context.Context, tx pgx.Tx, project int64, version int64,
 		WHERE project = $2
 		  AND path LIKE $3
 		  AND stop_version IS NULL
-		RETURNING path
 	`, version, project, pathPredicate)
 	if err != nil {
 		return fmt.Errorf("delete objects, project %v, version %v, path %v: %w", project, version, pathPredicate, err)
@@ -64,6 +63,25 @@ func UpdateObject(ctx context.Context, tx pgx.Tx, encoder *ContentEncoder, proje
 	encoded, err := encoder.Encode(content)
 	if err != nil {
 		return fmt.Errorf("encode updated content, project %v, version %v, path %v: %w", project, version, object.Path, err)
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT path
+		FROM dl.objects
+		WHERE project = $1
+		  AND path = $2
+		  AND stop_version IS NULL
+		  AND (hash).h1 = $3
+		  AND (hash).h2 = $4
+		  AND mode = $5
+	`, project, object.Path, h1, h2, object.Mode)
+	if err != nil {
+		return fmt.Errorf("select searching for existing object identical object, project %v, path %v: %w", project, object.Path, err)
+	}
+
+	defer rows.Close()
+	if rows.Next() {
+		return nil
 	}
 
 	batch := &pgx.Batch{}


### PR DESCRIPTION
One thing I've noticed while benchmarking Gadget's use case is that we often mark files as changed when they really haven't.

The clearest example is our generated code in `.gadget`. Upon any project change we update all of these files, by writing them to disk and updating their mod time. Because of mod time change, `fsdiff` considers them to have been updated.

DateiLager will not store duplicates, because everything is content addressable. But there is still a cost for duplicate objects, namely that they will go over the wire over and over again.

I don't love having to do an extra select here, I think we could add an index and do something with `ON CONFLICT` but I was afraid yet another index would cause storage creep.