### PR TITLE
Skip updating identical object

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,5 +1,5 @@
-name: 'Set up environment'
-description: ''
+name: "Set up environment"
+description: ""
 inputs: {}
 outputs: {}
 runs:
@@ -8,7 +8,7 @@ runs:
     - uses: cachix/install-nix-action@v14
       with:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+        install_options: "--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve"
         extra_nix_config: |
           experimental-features = nix-command flakes
 
@@ -45,6 +45,9 @@ runs:
       shell: nix develop -c bash -eo pipefail -l {0}
 
     - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      shell: nix develop -c bash -eo pipefail -l {0}
+
+    - run: dirname $(which go) >> $GITHUB_PATH
       shell: nix develop -c bash -eo pipefail -l {0}
 
     - run: make install

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648097358,
-        "narHash": "sha256-GMoTKP/po2Nbkh1tvPvP8Ww6NyFW8FFst1Z3nfzffZc=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d60081494259c0785f7e228518fee74e0792c1b",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
 
             mkcert = pkgs.mkcert;
 
-            go = pkgs.go;
+            go = pkgs.go_1_17;
 
             git = pkgs.git;
 

--- a/migrations/000004_identical_object_index.down.sql
+++ b/migrations/000004_identical_object_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX dl.identical_objects_idx;

--- a/migrations/000004_identical_object_index.up.sql
+++ b/migrations/000004_identical_object_index.up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX identical_objects_idx ON dl.objects
+    (project, (stop_version IS NULL), path, hash, mode) WHERE stop_version IS NULL;


### PR DESCRIPTION
This is a better version of: https://github.com/gadget-inc/dateilager/pull/26

As the test shows, this PR allows us to:

1. Create a DL project at version 1 with 3 files.
2. Update 1 file and only change the mod time on two others
3. All 3 will be sent up as changed files to DL
4. However, when rebuilding from version 1 to 2, only 1 diff will be applied

This allows us to cut down on how many objects we store in cases where we touch a bunch of files without modifying them. In Gadget this happens every time we rebuild client code.

This version of the change uses an index and `ON CONFLICT` trick. When you have an `ON CONFLICT DO NOTHING`, `RETURNING` will return no rows. Which means in the normal case we'll just insert the new row and when we do hit an identical object, we'll get an indication from the insert result without having to do any extra queries.

We also need to use a partial expression index to deal with the fact that two NULL values are not considered equal in SQL. This trick is best described here: https://www.enterprisedb.com/postgres-tutorials/postgresql-unique-constraint-null-allowing-only-one-null

Finally, adding the `WHERE stop_version IS NULL` predicate to the index will help keep the size of this index down.