### PR TITLE
Add context argument to close function

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-type CloseFunc func()
+type CloseFunc func(context.Context)
 
 type DbConnector interface {
 	Connect(context.Context) (pgx.Tx, CloseFunc, error)

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -31,7 +31,7 @@ func (d *DbTestConnector) Connect(ctx context.Context) (pgx.Tx, db.CloseFunc, er
 	if err != nil {
 		return nil, nil, err
 	}
-	return innerTx, func() {}, nil
+	return innerTx, func(context.Context) {}, nil
 }
 
 func (d *DbTestConnector) close(ctx context.Context) {

--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -62,7 +62,7 @@ func (f *Fs) NewProject(ctx context.Context, req *pb.NewProjectRequest) (*pb.New
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.NewProject[Init]", zap.Int64("id", req.Id), zap.Int64p("template", req.Template))
 
@@ -98,7 +98,7 @@ func (f *Fs) DeleteProject(ctx context.Context, req *pb.DeleteProjectRequest) (*
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.DeleteProject[Init]", zap.Int64("project", req.Project))
 	err = db.DeleteProject(ctx, tx, req.Project)
@@ -125,7 +125,7 @@ func (f *Fs) ListProjects(ctx context.Context, req *pb.ListProjectsRequest) (*pb
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.ListProjects[Query]")
 
@@ -169,7 +169,7 @@ func (f *Fs) Get(req *pb.GetRequest, stream pb.Fs_GetServer) error {
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	vrange, err := db.NewVersionRange(ctx, tx, req.Project, req.FromVersion, req.ToVersion)
 	if errors.Is(err, db.ErrNotFound) {
@@ -244,7 +244,7 @@ func (f *Fs) GetCompress(req *pb.GetCompressRequest, stream pb.Fs_GetCompressSer
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	vrange, err := db.NewVersionRange(ctx, tx, req.Project, req.FromVersion, req.ToVersion)
 	if errors.Is(err, db.ErrNotFound) {
@@ -315,7 +315,7 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	contentEncoder := db.NewContentEncoder()
 
@@ -422,7 +422,7 @@ func (f *Fs) Inspect(ctx context.Context, req *pb.InspectRequest) (*pb.InspectRe
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.Inspect[Query]", zap.Int64("project", req.Project))
 
@@ -492,7 +492,7 @@ func (f *Fs) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Snapsho
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.Snapshot[Query]")
 
@@ -520,7 +520,7 @@ func (f *Fs) Reset(ctx context.Context, req *pb.ResetRequest) (*pb.ResetResponse
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
-	defer close()
+	defer close(ctx)
 
 	f.Log.Debug("FS.Reset[Init]")
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,7 +66,7 @@ func (d *DbPoolConnector) Connect(ctx context.Context) (pgx.Tx, db.CloseFunc, er
 		return nil, nil, err
 	}
 
-	return tx, func() { tx.Rollback(ctx); conn.Release() }, nil
+	return tx, func(ctx context.Context) { tx.Rollback(ctx); conn.Release() }, nil
 }
 
 type Server struct {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -90,7 +90,7 @@ func createTestClient(tc util.TestCtx, fs *api.Fs) (*client.Client, db.CloseFunc
 
 	c := client.NewClientConn(tc.Logger(), conn)
 
-	return c, func() { c.Close(); s.Stop() }
+	return c, func(context.Context) { c.Close(); s.Stop() }
 }
 
 func verifyObjects(tc util.TestCtx, objects []*pb.Object, expected map[string]string) {
@@ -228,7 +228,7 @@ func TestGetLatestEmpty(t *testing.T) {
 	writeProject(tc, 1, 1)
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
 	if err != nil {
@@ -250,7 +250,7 @@ func TestGetLatest(t *testing.T) {
 	writeObject(tc, 1, 2, nil, "/c", "c v2")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
 	if err != nil {
@@ -283,7 +283,7 @@ func TestGetVersion(t *testing.T) {
 	writeObject(tc, 1, 3, nil, "/d", "d v3")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	objects, err := c.Get(tc.Context(), 1, "", toVersion(1))
 	if err != nil {
@@ -320,7 +320,7 @@ func TestGetVersionMissingProject(t *testing.T) {
 	defer tc.Close()
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	objects, err := c.Get(tc.Context(), 1, "", toVersion(1))
 	if err == nil {
@@ -338,7 +338,7 @@ func TestRebuild(t *testing.T) {
 	writeObject(tc, 1, 1, nil, "/c", "c v1")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -375,7 +375,7 @@ func TestRebuildWithOverwritesAndDeletes(t *testing.T) {
 	writeSymlink(tc, 1, 2, nil, "/e", "a")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{
 		"/a": "a v1 - long buffer of content",
@@ -416,7 +416,7 @@ func TestRebuildWithEmptyDirAndSymlink(t *testing.T) {
 	writeSymlink(tc, 1, 2, nil, "/f/g/h", "/d/e")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -450,7 +450,7 @@ func TestRebuildWithUpdatedEmptyDirectories(t *testing.T) {
 	writeEmptyDir(tc, 1, 1, nil, "/b/")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -526,7 +526,7 @@ func TestRebuildWithManyObjects(t *testing.T) {
 	}
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -568,7 +568,7 @@ func TestUpdateObjects(t *testing.T) {
 	})
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	version, count, err := c.Update(tc.Context(), 1, diff, tmpDir)
 	if err != nil {
@@ -621,7 +621,7 @@ func TestUpdateWithManyObjects(t *testing.T) {
 	diff := buildDiff(tc, updates)
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	version, count, err := c.Update(tc.Context(), 1, diff, tmpDir)
 	if err != nil {
@@ -670,7 +670,7 @@ func TestUpdateObjectsWithMissingFile(t *testing.T) {
 	os.Remove(filepath.Join(tmpDir, "d"))
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	version, count, err := c.Update(tc.Context(), 1, diff, tmpDir)
 	if err != nil {
@@ -704,7 +704,7 @@ func TestUpdateAndRebuild(t *testing.T) {
 	writeObject(tc, 1, 1, nil, "/c", "c v1")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -773,7 +773,7 @@ func TestUpdateAndRebuildWithIdenticalObjects(t *testing.T) {
 	writeObject(tc, 1, 1, nil, "/c", "c v1")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -851,7 +851,7 @@ func TestUpdateAndRebuildWithPacked(t *testing.T) {
 	writeObject(tc, 1, 1, nil, "/b", "b v1")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -922,7 +922,7 @@ func TestUpdateAndRebuildWithIdenticalPackedObjects(t *testing.T) {
 	writeObject(tc, 1, 1, nil, "/b", "b v1")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	tmpDir := writeTmpFiles(tc, map[string]string{})
 	defer os.RemoveAll(tmpDir)
@@ -998,7 +998,7 @@ func TestDeleteProject(t *testing.T) {
 	writeObject(tc, 1, 2, nil, "/c", "c v2")
 
 	c, close := createTestClient(tc, tc.FsApi())
-	defer close()
+	defer close(tc.Context())
 
 	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
 	if err != nil {


### PR DESCRIPTION
Extracted from #28.

> I added the ctx argument here so that our tx.rollback spans use the passed in context instead of the one captured in the closure. Makes our spans in honeycomb look nicer.

Not relevant yet but will be soon 😄  