### PR TITLE
Propagate otel-context

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"reflect"
 	"time"
 
@@ -47,18 +46,7 @@ func (t Type) String() string {
 }
 
 func Init(ctx context.Context, t Type) (shutdown func(), err error) {
-	endpoint := os.Getenv("OTEL_COLLECTOR_TRACE_ENDPOINT")
-	if endpoint == "" {
-		return func() {}, nil
-	}
-
-	// FIXME: Make this secure
-	client := otlptracehttp.NewClient(
-		otlptracehttp.WithEndpoint(endpoint),
-		otlptracehttp.WithInsecure(),
-	)
-
-	traceExporter, err := otlptrace.New(ctx, client)
+	traceExporter, err := otlptrace.New(ctx, otlptracehttp.NewClient())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.1.0",
+        "@opentelemetry/api": "^1.0.4",
         "@protobuf-ts/grpc-transport": "^2.0.7",
         "@protobuf-ts/plugin": "^2.0.7",
         "@protobuf-ts/runtime-rpc": "^2.0.7",
@@ -931,6 +932,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobuf-ts/grpc-transport": {
@@ -5603,6 +5612,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
     },
     "@protobuf-ts/grpc-transport": {
       "version": "2.1.0",

--- a/js/package.json
+++ b/js/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@grpc/grpc-js": "^1.1.0",
+    "@opentelemetry/api": "^1.0.4",
     "@protobuf-ts/grpc-transport": "^2.0.7",
     "@protobuf-ts/plugin": "^2.0.7",
     "@protobuf-ts/runtime-rpc": "^2.0.7",


### PR DESCRIPTION
This propagates open telemetry context from the JS client to the binary client.