### PR TITLE
Added custom sampler to ignore health checks

### DIFF
--- a/internal/telemetry/sampler.go
+++ b/internal/telemetry/sampler.go
@@ -1,0 +1,27 @@
+package telemetry
+
+import (
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type sampler struct{}
+
+func (s sampler) ShouldSample(params sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	psc := trace.SpanContextFromContext(params.ParentContext)
+	if params.Name == "grpc.health.v1.Health/Check" {
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.Drop,
+			Tracestate: psc.TraceState(),
+		}
+	}
+
+	return sdktrace.SamplingResult{
+		Decision:   sdktrace.RecordAndSample,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (s sampler) Description() string {
+	return "DateilagerSampler"
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -95,6 +95,7 @@ func Init(ctx context.Context, t Type) (shutdown func(), err error) {
 	traceProvider := sdktrace.NewTracerProvider(
 		sdktrace.WithResource(res),
 		sdktrace.WithBatcher(traceExporter),
+		sdktrace.WithSampler(sdktrace.ParentBased(sampler{})),
 	)
 
 	otel.SetTracerProvider(traceProvider)


### PR DESCRIPTION
I'm noticing a lot of health check traces in honeycomb. I don't think they're necessary so this custom sampler will filter them out.