### PR TITLE
Support specifying `DL_TOKEN` by file

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -405,7 +405,17 @@ func main() {
 
 	token := os.Getenv("DL_TOKEN")
 	if token == "" {
-		stdlog.Fatal("missing token: set the DL_TOKEN environment variable")
+		tokenFile := os.Getenv("DL_TOKEN_FILE")
+		if tokenFile == "" {
+			stdlog.Fatal("missing token: set the DL_TOKEN or DL_TOKEN_FILE environment variable")
+		}
+
+		bytes, err := os.ReadFile(tokenFile)
+		if err != nil {
+			stdlog.Fatal("failed to read contents of DL_TOKEN_FILE: %v", err)
+		}
+
+		token = string(bytes)
 	}
 
 	err = initLogger(*shared.level, *shared.encoding)

--- a/cmd/webui/main.go
+++ b/cmd/webui/main.go
@@ -51,7 +51,17 @@ func main() {
 
 	token := os.Getenv("DL_TOKEN")
 	if token == "" {
-		log.Fatal("missing token: set the DL_TOKEN environment variable")
+		tokenFile := os.Getenv("DL_TOKEN_FILE")
+		if tokenFile == "" {
+			log.Fatal("missing token: set the DL_TOKEN or DL_TOKEN_FILE environment variable")
+		}
+
+		bytes, err := os.ReadFile(tokenFile)
+		if err != nil {
+			log.Fatal("failed to read contents of DL_TOKEN_FILE", zap.Error(err))
+		}
+
+		token = string(bytes)
 	}
 
 	c, err := client.NewClient(ctx, args.server, token)


### PR DESCRIPTION
This acts as a "pointer" to let us move the dateilager token generation to the setup phase in our Gadget services, so we're not forced to generate it in the env phase.