### PR TITLE
Respect ignores when requesting files with a non-null from version.

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -130,7 +130,7 @@ func parseGetArgs(args []string) (*sharedArgs, *getArgs, error) {
 }
 
 func (a *getArgs) run(ctx context.Context, c *client.Client) error {
-	objects, err := c.Get(ctx, a.project, a.prefix, a.vrange)
+	objects, err := c.Get(ctx, a.project, a.prefix, nil, a.vrange)
 	if err != nil {
 		return fmt.Errorf("could not fetch data: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/minio/sha256-simd v1.0.0
 	github.com/o1egl/paseto v1.0.0
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0
 	go.opentelemetry.io/otel v1.6.3
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/db/query.go
+++ b/internal/db/query.go
@@ -169,6 +169,7 @@ func buildQuery(project int64, vrange VersionRange, objectQuery *pb.ObjectQuery)
 			  AND o.start_version <= $3
 			  AND o.stop_version > $2
 			  AND o.stop_version <= $3
+			  AND o.path NOT LIKE ALL($5::text[])
 			  AND o.path NOT IN (SELECT path FROM updated_files)
 			ORDER BY o.path
 		)

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -32,6 +32,7 @@ const (
 	TotalObjectsCount = Int64Key("dl.total_objects_count")
 	Version           = Int64Key("dl.version")
 	Worker            = IntKey("dl.worker")
+	Ignores           = StringSliceKey("dl.ignores")
 )
 
 type BoolKey string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -144,12 +144,13 @@ func (c *Client) DeleteProject(ctx context.Context, project int64) error {
 	return nil
 }
 
-func (c *Client) Get(ctx context.Context, project int64, prefix string, vrange VersionRange) ([]*pb.Object, error) {
+func (c *Client) Get(ctx context.Context, project int64, prefix string, ignores []string, vrange VersionRange) ([]*pb.Object, error) {
 	ctx, span := telemetry.Start(ctx, "client.get", trace.WithAttributes(
 		key.Project.Attribute(project),
 		key.Prefix.Attribute(prefix),
 		key.FromVersion.Attribute(vrange.From),
 		key.ToVersion.Attribute(vrange.To),
+		key.Ignores.Attribute(ignores),
 	))
 	defer span.End()
 
@@ -159,6 +160,7 @@ func (c *Client) Get(ctx context.Context, project int64, prefix string, vrange V
 		Path:        prefix,
 		IsPrefix:    true,
 		WithContent: true,
+		Ignores:     ignores,
 	}
 
 	request := &pb.GetRequest{

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -134,7 +134,7 @@ type VersionData struct {
 
 func fetchVersionData(ctx context.Context, dlc *client.Client, project, version int64) (*VersionData, error) {
 	vrange := client.VersionRange{From: nil, To: &version}
-	get, err := dlc.Get(ctx, project, "", vrange)
+	get, err := dlc.Get(ctx, project, "", nil, vrange)
 	if err != nil {
 		return nil, err
 	}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -95,7 +95,7 @@ func createTestClient(tc util.TestCtx, fs *api.Fs) (*client.Client, db.CloseFunc
 	return c, func(context.Context) { c.Close(); s.Stop() }
 }
 
-// asserts that the given objects contian all the expected paths and file contents
+// asserts that the given objects contain all the expected paths and file contents
 func assertObjects(t *testing.T, objects []*pb.Object, expected map[string]string) {
 	contents := make(map[string]string)
 

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gadget-inc/dateilager/pkg/client"
 	fsdiff_pb "github.com/gadget-inc/fsdiff/pkg/pb"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -93,21 +95,16 @@ func createTestClient(tc util.TestCtx, fs *api.Fs) (*client.Client, db.CloseFunc
 	return c, func(context.Context) { c.Close(); s.Stop() }
 }
 
-func verifyObjects(tc util.TestCtx, objects []*pb.Object, expected map[string]string) {
-	if len(expected) != len(objects) {
-		tc.Errorf("expected %v objects, got: %v", len(expected), len(objects))
-	}
+// asserts that the given objects contian all the expected paths and file contents
+func assertObjects(t *testing.T, objects []*pb.Object, expected map[string]string) {
+	contents := make(map[string]string)
 
 	for _, object := range objects {
-		content, ok := expected[object.Path]
-		if !ok {
-			tc.Fatalf("object path %v not in expected objects", object.Path)
-		}
-
-		if string(object.Content) != content {
-			tc.Errorf("content mismatch for %v expected '%v', got '%v'", object.Path, content, string(object.Content))
-		}
+		contents[object.Path] = string(object.Content)
 	}
+
+	// This gives in a much nicer diff in the error message over asserting each object separately.
+	assert.EqualValues(t, expected, contents, "unexpected contents for objects")
 }
 
 func writeTmpFiles(tc util.TestCtx, files map[string]string) string {
@@ -230,7 +227,7 @@ func TestGetLatestEmpty(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
+	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	if err != nil {
 		t.Fatalf("client.GetLatest empty: %v", err)
 	}
@@ -240,39 +237,7 @@ func TestGetLatestEmpty(t *testing.T) {
 	}
 }
 
-func TestGetLatest(t *testing.T) {
-	tc := util.NewTestCtx(t, auth.Project, 1)
-	defer tc.Close()
-
-	writeProject(tc, 1, 2)
-	writeObject(tc, 1, 1, i(2), "/a", "a v1")
-	writeObject(tc, 1, 1, nil, "/b", "b v1")
-	writeObject(tc, 1, 2, nil, "/c", "c v2")
-
-	c, close := createTestClient(tc, tc.FsApi())
-	defer close(tc.Context())
-
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
-	if err != nil {
-		t.Fatalf("client.GetLatest with results: %v", err)
-	}
-
-	verifyObjects(tc, objects, map[string]string{
-		"/b": "b v1",
-		"/c": "c v2",
-	})
-
-	objects, err = c.Get(tc.Context(), 1, "/c", emptyVersionRange)
-	if err != nil {
-		t.Fatalf("client.GetLatest with results: %v", err)
-	}
-
-	verifyObjects(tc, objects, map[string]string{
-		"/c": "c v2",
-	})
-}
-
-func TestGetVersion(t *testing.T) {
+func TestGet(t *testing.T) {
 	tc := util.NewTestCtx(t, auth.Project, 1)
 	defer tc.Close()
 
@@ -285,34 +250,92 @@ func TestGetVersion(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	objects, err := c.Get(tc.Context(), 1, "", toVersion(1))
-	if err != nil {
-		t.Fatalf("client.GetLatest with results: %v", err)
+	testCases := []struct {
+		name     string
+		project  int64
+		prefix   string
+		ignores  []string
+		vrange   client.VersionRange
+		expected map[string]string
+	}{
+		{
+			name:    "get version 1",
+			project: 1,
+			vrange:  toVersion(1),
+			expected: map[string]string{
+				"/a": "a v1",
+				"/b": "b v1",
+			},
+		},
+		{
+			name:    "get version 2",
+			project: 1,
+			vrange:  toVersion(2),
+			expected: map[string]string{
+				"/b": "b v1",
+				"/c": "c v2",
+			},
+		},
+		{
+			name:    "get version with prefix",
+			project: 1,
+			prefix:  "/b",
+			vrange:  toVersion(2),
+			expected: map[string]string{
+				"/b": "b v1",
+			},
+		},
+		{
+			name:    "get latest version",
+			project: 1,
+			vrange:  emptyVersionRange,
+			expected: map[string]string{
+				"/b": "b v1",
+				"/c": "c v2",
+				"/d": "d v3",
+			},
+		},
+		{
+			name:    "get latest version with prefix",
+			project: 1,
+			prefix:  "/c",
+			vrange:  emptyVersionRange,
+			expected: map[string]string{
+				"/c": "c v2",
+			},
+		},
+		{
+			name:    "get latest version with ignores",
+			project: 1,
+			prefix:  "",
+			ignores: []string{"/b"},
+			vrange:  emptyVersionRange,
+			expected: map[string]string{
+				"/c": "c v2",
+				"/d": "d v3",
+			},
+		},
+		{
+			name:    "get latest version with ignores and deleted files",
+			project: 1,
+			prefix:  "",
+			ignores: []string{"/a"},
+			vrange:  fromVersion(1), // makes sure the query includes deleted files
+			expected: map[string]string{
+				"/c": "c v2",
+				"/d": "d v3",
+			},
+		},
 	}
 
-	verifyObjects(tc, objects, map[string]string{
-		"/a": "a v1",
-		"/b": "b v1",
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			objects, err := c.Get(tc.Context(), testCase.project, testCase.prefix, testCase.ignores, testCase.vrange)
+			require.NoError(t, err, "client.Get")
 
-	objects, err = c.Get(tc.Context(), 1, "", toVersion(2))
-	if err != nil {
-		t.Fatalf("client.GetLatest with results: %v", err)
+			assertObjects(t, objects, testCase.expected)
+		})
 	}
-
-	verifyObjects(tc, objects, map[string]string{
-		"/b": "b v1",
-		"/c": "c v2",
-	})
-
-	objects, err = c.Get(tc.Context(), 1, "/b", toVersion(2))
-	if err != nil {
-		t.Fatalf("client.GetLatest with results: %v", err)
-	}
-
-	verifyObjects(tc, objects, map[string]string{
-		"/b": "b v1",
-	})
 }
 
 func TestGetVersionMissingProject(t *testing.T) {
@@ -322,7 +345,7 @@ func TestGetVersionMissingProject(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	objects, err := c.Get(tc.Context(), 1, "", toVersion(1))
+	objects, err := c.Get(tc.Context(), 1, "", nil, toVersion(1))
 	if err == nil {
 		t.Fatalf("client.GetLatest didn't error accessing objects: %v", objects)
 	}
@@ -581,12 +604,12 @@ func TestUpdateObjects(t *testing.T) {
 		t.Errorf("expected update count to be 3, got: %v", count)
 	}
 
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
+	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	if err != nil {
 		t.Fatalf("client.GetLatest after update: %v", err)
 	}
 
-	verifyObjects(tc, objects, map[string]string{
+	assertObjects(t, objects, map[string]string{
 		"/a": "a v2",
 		"/b": "b v1",
 		"/c": "c v2",
@@ -634,12 +657,12 @@ func TestUpdateWithManyObjects(t *testing.T) {
 		t.Errorf("expected update count to be 500, got: %v", count)
 	}
 
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
+	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	if err != nil {
 		t.Fatalf("client.GetLatest after update: %v", err)
 	}
 
-	verifyObjects(tc, objects, fixtureFiles)
+	assertObjects(t, objects, fixtureFiles)
 }
 
 func TestUpdateObjectsWithMissingFile(t *testing.T) {
@@ -683,12 +706,12 @@ func TestUpdateObjectsWithMissingFile(t *testing.T) {
 		t.Errorf("expected update count to be 3, got: %v", count)
 	}
 
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
+	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	if err != nil {
 		t.Fatalf("client.GetLatest after update: %v", err)
 	}
 
-	verifyObjects(tc, objects, map[string]string{
+	assertObjects(t, objects, map[string]string{
 		"/a": "a v2",
 		"/b": "b v1",
 	})
@@ -1000,12 +1023,12 @@ func TestDeleteProject(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	objects, err := c.Get(tc.Context(), 1, "", emptyVersionRange)
+	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	if err != nil {
 		t.Fatalf("client.GetLatest with results: %v", err)
 	}
 
-	verifyObjects(tc, objects, map[string]string{
+	assertObjects(t, objects, map[string]string{
 		"/b": "b v1",
 		"/c": "c v2",
 	})
@@ -1015,7 +1038,7 @@ func TestDeleteProject(t *testing.T) {
 		t.Fatalf("client.DeleteProject with results: %v", err)
 	}
 
-	objects, err = c.Get(tc.Context(), 1, "", toVersion(1))
+	objects, err = c.Get(tc.Context(), 1, "", nil, toVersion(1))
 	if err == nil {
 		t.Fatalf("client.GetLatest didn't error accessing objects: %v", objects)
 	}


### PR DESCRIPTION
## What

The query we use to fetch objects doesn't include deleted files when `fromVersion == nil` but when you do set a `fromVersion` the query for deleted files wasn't respected the `ignores` that is was given and so the results were including deleted files.

This also adds the `github.com/stretchr/testify` testing package which is widely used in go projects. It produces much nicer diffs than the standard go test.