### PR TITLE
Bump default nix version to v0.043 (latest).

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@
 
 buildGoModule rec {
   pname = "dateilager";
-  version = "0.0.41";
+  version = "0.0.43";
   src = ./.;
   proxyVendor = true; # Fixes: cannot query module due to -mod=vendor running make install
   vendorSha256 = "sha256-GGrJJeQe4hvgoChIq/YHXwE34a1T/vYLk9FfTxWFHdQ=";


### PR DESCRIPTION
Bump default nix version to v0.043 (latest).