### PR TITLE
Flake changes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -71,6 +71,11 @@ buildGoModule rec {
     ln -s "$client/bin/dateilager-client" "$server/bin/dateilager-server" "$webui/bin/dateilager-webui" "$out/bin"
   '';
 
+  shellHook = ''
+    export GOPATH=$(mktemp -d)
+    export PATH="$GOPATH/bin:$PATH"
+  '';
+
   meta = with lib; {
     description = "A shared file system";
     homepage = "https://github.com/gadget-inc/dateilager";


### PR DESCRIPTION
This adds a `devShell` that changes the `GOPATH` to point to the `tmp` directory so that `go install` compiles packages in an isolated area specific to this repo instead of the default place `~/go`. This solves an issue I'm having where different go versions are trying to compile binaries in the same place -- causing `go install` to fail.

This also `mkcert` and `protobuf` (protoc) back to flake.nix.