### PR TITLE
Give the shutdown up to a second to complete

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -150,6 +150,9 @@ func Init(ctx context.Context, t Type) (shutdown func(), err error) {
 	})
 
 	return func() {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
 		_ = traceProvider.Shutdown(ctx)
 	}, nil
 }


### PR DESCRIPTION
Tested this with a local HTTP server that hangs forever.

By default it would wait 10 seconds, 2 seconds longer than our timeout in Gadget.

```
❯ make client-get
go run cmd/client/main.go get -project 1 -server localhost:5051 -prefix "" -tracing
OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:3000/
2022-06-08T18:14:03.276+0200	info	logger/logger.go:41	listing objects in project	{"dl.project": 1, "dl.object_count": 7}
2022/06/08 18:14:13 Post "http://127.0.0.1:3000/v1/traces": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

This now gives it only 1 second.