### PR TITLE
Return a list of the files that changed after an update in the binary JS client

### DIFF
--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -3,12 +3,17 @@ import { encodeContent } from "../src";
 import { binaryClient, grpcClient, tmpdir } from "./util";
 
 describe("binary client operations", () => {
-  it("can rebuild the file system", async () => {
-    const project = 1337n;
-    const path = "hello.txt";
-    const content = "hello world";
+  const project = 1337n;
+  const path = "hello.txt";
+  let dir: string;
 
+  beforeEach(async () => {
+    dir = tmpdir();
     await grpcClient.newProject(project, []);
+  });
+
+  it("can rebuild the file system", async () => {
+    const content = "hello world";
     const encodedContent = encodeContent(content);
 
     await grpcClient.updateObject(project, {
@@ -19,7 +24,6 @@ describe("binary client operations", () => {
       deleted: false,
     });
 
-    const dir = tmpdir();
     await binaryClient.rebuild(project, null, dir);
 
     const filepath = `${dir}/${path}`;
@@ -27,5 +31,30 @@ describe("binary client operations", () => {
 
     const fileContent = fs.readFileSync(filepath).toString();
     expect(fileContent).toBe(content);
+  });
+
+  it("can update the file system", async () => {
+    await binaryClient.rebuild(project, null, dir);
+
+    const filepath = `${dir}/${path}`;
+    fs.writeFileSync(filepath, "hello world", { encoding: "utf8" });
+
+    const result = await binaryClient.update(project, dir);
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(1n);
+    expect(result!.updates).toEqual([
+      {
+        operation: "ADD",
+        path: path,
+      },
+    ]);
+  });
+
+  it("updates where nothing change return a result", async () => {
+    await binaryClient.rebuild(project, null, dir);
+    const result = await binaryClient.update(project, dir);
+    expect(result).toBeTruthy();
+    expect(result!.version).toEqual(0n);
+    expect(result!.updates).toEqual([]);
   });
 });

--- a/js/spec/jest.setup.ts
+++ b/js/spec/jest.setup.ts
@@ -1,15 +1,10 @@
-import type { Project } from "../src";
 import { grpcClient } from "./util";
 
-let snapshot: Project[];
-
 beforeEach(async () => {
-  snapshot = await grpcClient.snapshotInDevOrTests();
+  await grpcClient.resetToSnapshotInDevOrTests([]);
 });
 
-afterEach(async () => {
-  await grpcClient.resetToSnapshotInDevOrTests(snapshot);
-});
+afterEach(async () => {});
 
 afterAll(() => {
   grpcClient.close();

--- a/js/src/binary-client.ts
+++ b/js/src/binary-client.ts
@@ -85,6 +85,22 @@ export interface DateiLagerBinaryClientOptions {
 }
 
 /**
+ * A record of one file being changed during an update operation
+ **/
+export interface Update {
+  operation: "ADD" | "DELETE" | "CHANGE";
+  path: string;
+}
+
+/**
+ * The result of running an update operation. Reports the new project version, and a list of updated files.
+ */
+export interface UpdateResult {
+  version: bigint;
+  updates: Update[];
+}
+
+/**
  * A version of the DateiLager client that uses the compiled binary client instead of the Javascript one.
  *
  * Useful for working directly with a real filesystem instead of in memory objects.
@@ -124,9 +140,9 @@ export class DateiLagerBinaryClient {
    * @param    directory       The path of the directory to send updates from.
    * @param    options         Object of options.
    * @param    options.timeout Number of milliseconds to wait before terminating the process.
-   * @returns                  The latest project version or `null` if something went wrong.
+   * @returns                  An update result or `null` if something went wrong.
    */
-  public async update(project: bigint, directory: string, options?: { timeout: number }): Promise<bigint | null> {
+  public async update(project: bigint, directory: string, options?: { timeout: number }): Promise<UpdateResult | null> {
     return await trace(
       "dateilager-binary-client.update",
       {
@@ -138,11 +154,20 @@ export class DateiLagerBinaryClient {
       async () => {
         const result = await this._call("update", project, directory, ["--dir", directory], options);
 
-        if (result.stdout == "-1") {
+        const lines = result.stdout.split("\n");
+        const versionLine = lines.pop()!.trim();
+
+        if (versionLine == "-1") {
           return null;
         }
 
-        return BigInt(result.stdout);
+        return {
+          updates: lines.map((line) => {
+            const [operation, path] = line.split(/ (.+)?/, 2);
+            return { operation: operation as any, path: path as string };
+          }),
+          version: BigInt(versionLine),
+        };
       }
     );
   }

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -22,7 +22,7 @@ func NewCmdUpdate() *cobra.Command {
 
 			client := client.FromContext(ctx)
 
-			version, count, err := client.Update(ctx, project, dir)
+			version, diff, err := client.Update(ctx, project, dir)
 			if err != nil {
 				return fmt.Errorf("update objects: %w", err)
 			}
@@ -30,8 +30,12 @@ func NewCmdUpdate() *cobra.Command {
 			logger.Info(ctx, "updated objects",
 				key.Project.Field(project),
 				key.Version.Field(version),
-				key.DiffCount.Field(count),
+				key.DiffCount.Field(uint32(len(diff.Updates))),
 			)
+
+			for _, update := range diff.Updates {
+				fmt.Printf("%v %v\n", update.Action, update.Path)
+			}
 			fmt.Println(version)
 
 			return nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -407,7 +407,7 @@ func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVe
 	return *toVersion, diffCount, nil
 }
 
-func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int64, uint32, error) {
+func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int64, *fsdiff_pb.Diff, error) {
 	rootCtx, span := telemetry.Start(rootCtx, "client.update", trace.WithAttributes(
 		key.Project.Attribute(project),
 		key.Directory.Attribute(dir),
@@ -416,16 +416,16 @@ func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int
 
 	fromVersion, err := ReadVersionFile(dir)
 	if err != nil {
-		return -1, 0, err
+		return -1, nil, err
 	}
 
 	diff, err := DiffAndSummarize(dir)
 	if err != nil {
-		return -1, 0, err
+		return -1, nil, err
 	}
 
 	if len(diff.Updates) == 0 {
-		return fromVersion, 0, nil
+		return fromVersion, diff, nil
 	}
 
 	toVersion := int64(-1)
@@ -518,24 +518,22 @@ func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int
 
 	err = group.Wait()
 	if err != nil {
-		return -1, 0, err
+		return -1, nil, err
 	}
-
-	updateCount := uint32(len(diff.Updates))
 
 	if (fromVersion + 1) == toVersion {
 		err = WriteVersionFile(dir, toVersion)
 		if err != nil {
-			return -1, updateCount, err
+			return -1, diff, err
 		}
 	} else {
 		toVersion, _, err = c.Rebuild(rootCtx, project, "", nil, dir)
 		if err != nil {
-			return -1, updateCount, err
+			return -1, nil, err
 		}
 	}
 
-	return toVersion, updateCount, nil
+	return toVersion, diff, nil
 }
 
 func (c *Client) Inspect(ctx context.Context, project int64) (*pb.InspectResponse, error) {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -531,10 +531,10 @@ func TestUpdateObjects(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	version, count, err := c.Update(tc.Context(), 1, tmpDir)
+	version, diff, err := c.Update(tc.Context(), 1, tmpDir)
 	require.NoError(t, err, "client.Update")
 	assert.Equal(t, int64(2), version, "expected update version to be 2")
-	assert.Equal(t, uint32(3), count, "expected update count to be 3")
+	assert.Equal(t, uint32(3), uint32(len(diff.Updates)), "expected update count to be 3")
 
 	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	require.NoError(t, err, "client.GetLatest after update")
@@ -573,10 +573,10 @@ func TestUpdateWithManyObjects(t *testing.T) {
 	c, close := createTestClient(tc, tc.FsApi())
 	defer close(tc.Context())
 
-	version, count, err := c.Update(tc.Context(), 1, tmpDir)
+	version, diff, err := c.Update(tc.Context(), 1, tmpDir)
 	require.NoError(t, err, "client.Update")
 	assert.Equal(t, int64(1), version, "expected update version to be 1")
-	assert.Equal(t, uint32(500), count, "expected update count to be 500")
+	assert.Equal(t, uint32(500), uint32(len(diff.Updates)), "expected update count to be 500")
 
 	objects, err := c.Get(tc.Context(), 1, "", nil, emptyVersionRange)
 	require.NoError(t, err, "client.GetLatest after update")
@@ -666,10 +666,10 @@ func TestUpdateAndRebuildWithIdenticalObjects(t *testing.T) {
 
 	writeFile(t, tmpDir, "c", "c v2")
 
-	version, count, err = c.Update(tc.Context(), 1, tmpDir)
+	version, diff, err := c.Update(tc.Context(), 1, tmpDir)
 	require.NoError(t, err, "client.Update")
 	assert.Equal(t, int64(2), version, "expected update version to be 2")
-	assert.Equal(t, uint32(3), count, "expected update count to be 3")
+	assert.Equal(t, uint32(3), uint32(len(diff.Updates)), "expected update count to be 3")
 
 	// Reset the tmpdir to remove all state and updates
 	os.RemoveAll(tmpDir)
@@ -777,10 +777,10 @@ func TestUpdateAndRebuildWithIdenticalPackedObjects(t *testing.T) {
 
 	writeFile(t, tmpDir, "b", "b v2")
 
-	version, count, err = c.Update(tc.Context(), 1, tmpDir)
+	version, diff, err := c.Update(tc.Context(), 1, tmpDir)
 	require.NoError(t, err, "client.Update")
 	assert.Equal(t, int64(2), version, "expected update version to be 2")
-	assert.Equal(t, uint32(3), count, "expected update count to be 3")
+	assert.Equal(t, uint32(3), uint32(len(diff.Updates)), "expected update count to be 3")
 
 	os.RemoveAll(tmpDir)
 	err = os.Mkdir(tmpDir, 0775)
@@ -831,10 +831,10 @@ func TestConcurrentUpdatesSetsCorrectMetadata(t *testing.T) {
 	c, close := createTestClient(tc, fs)
 	defer close(tc.Context())
 
-	version, count, err := c.Update(tc.Context(), 1, tmpDir)
+	version, diff, err := c.Update(tc.Context(), 1, tmpDir)
 	require.NoError(t, err, "client.Update")
 	assert.Equal(t, int64(3), version, "expected update version to be 3")
-	assert.Equal(t, uint32(2), count, "expected update count to be 2")
+	assert.Equal(t, uint32(2), uint32(len(diff.Updates)), "expected update count to be 2")
 
 	verifyDir(t, tmpDir, 3, map[string]expectedFile{
 		"a": {content: "a v3"},


### PR DESCRIPTION
I want this gadget side to be able to trigger specific business logic when important files like package.json change after running commands! This returns the list of files that changed instead of just a count, so the caller can do more stuff. I think this list could potentially be long after a huge update, but not outrageously unreasonably long, so it should be alright performance wise?
