### PR TITLE
0.1.1 with remove empty dirs

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -150,6 +150,9 @@ func Init(ctx context.Context, t Type) (shutdown func(), err error) {
 	})
 
 	return func() {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
 		_ = traceProvider.Shutdown(ctx)
 	}, nil
 }

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -106,7 +106,9 @@ func verifyObjects(t *testing.T, objects []*pb.Object, expected map[string]strin
 
 func writeFile(t *testing.T, dir string, path string, content string) {
 	fullPath := filepath.Join(dir, path)
-	err := os.WriteFile(fullPath, []byte(content), 0755)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+	require.NoError(t, err, "mkdir %v", filepath.Dir(fullPath))
+	err = os.WriteFile(fullPath, []byte(content), 0755)
 	require.NoError(t, err, "write file %v", path)
 }
 
@@ -794,6 +796,52 @@ func TestUpdateAndRebuildWithIdenticalPackedObjects(t *testing.T) {
 
 	// Only one file should be updated since /a and /b were identical but with a new mod times
 	assert.Equal(t, uint32(1), count, "expected rebuild count to be 1")
+}
+
+func TestUpdateWithEmptyDirectories(t *testing.T) {
+	tc := util.NewTestCtx(t, auth.Project, 1)
+	defer tc.Close()
+
+	writeProject(tc, 1, 1)
+	writeEmptyDir(tc, 1, 1, nil, "a/")
+	writeEmptyDir(tc, 1, 1, nil, "b/")
+	writeEmptyDir(tc, 1, 1, nil, "c/")
+
+	fs := tc.FsApi()
+	c, close := createTestClient(tc, fs)
+	defer close(tc.Context())
+
+	tmpDir := emptyTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	version, count, err := c.Rebuild(tc.Context(), 1, "", nil, tmpDir)
+	require.NoError(t, err, "client.Rebuild")
+	assert.Equal(t, int64(1), version, "expected rebuild version to be 1")
+	assert.Equal(t, uint32(3), count, "expected rebuild count to be 3")
+
+	verifyDir(t, tmpDir, 1, map[string]expectedFile{
+		"a/": {content: "", fileType: typeDirectory},
+		"b/": {content: "", fileType: typeDirectory},
+		"c/": {content: "", fileType: typeDirectory},
+	})
+
+	writeFile(t, tmpDir, "a/b", "a/b v2")
+	writeFile(t, tmpDir, "b/c/d", "b/c/d v2")
+
+	version, count, err = c.Update(tc.Context(), 1, tmpDir)
+	require.NoError(t, err, "client.Update")
+	assert.Equal(t, int64(2), version, "expected update version to be 2")
+	assert.Equal(t, uint32(2), count, "expected update count to be 1")
+
+	stream := &mockGetServer{ctx: tc.Context()}
+	err = fs.Get(prefixQuery(1, nil, ""), stream)
+	require.NoError(t, err, "fs.Get")
+
+	verifyStreamResults(t, stream.results, map[string]expectedObject{
+		"a/b":   {content: "a/b v2"},
+		"b/c/d": {content: "b/c/d v2"},
+		"c/":    {content: ""},
+	})
 }
 
 func TestConcurrentUpdatesSetsCorrectMetadata(t *testing.T) {

--- a/test/shared.go
+++ b/test/shared.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"io/fs"
+	"os"
 
 	"github.com/gadget-inc/dateilager/internal/db"
 	"github.com/gadget-inc/dateilager/internal/pb"
@@ -164,7 +165,7 @@ func debugObjects(tc util.TestCtx) {
 	require.NoError(tc.T(), err, "debug execute object list")
 
 	fmt.Println("\n[DEBUG] Objects")
-	fmt.Println("project,\tstart_version,\tstop_version,\tpath,\tmode,\tsize,\tpacked")
+	fmt.Println("project,\tstart_version,\tstop_version,\tpath,\tmode,\t\tsize,\tpacked")
 
 	for rows.Next() {
 		var project, start_version, mode, size int64
@@ -174,8 +175,19 @@ func debugObjects(tc util.TestCtx) {
 		err = rows.Scan(&project, &start_version, &stop_version, &path, &mode, &size, &packed)
 		require.NoError(tc.T(), err, "debug scan object")
 
-		fmt.Printf("%d,\t\t%d,\t\t%d,\t\t%s,\t%d,\t%d,\t%v\n", project, start_version, stop_version, path, mode, size, packed)
+		fmt.Printf("%d,\t\t%d,\t\t%s,\t\t%s,\t%s,\t%d,\t%v\n", project, start_version, formatPtr(stop_version), path, formatMode(mode), size, packed)
 	}
 
 	fmt.Println()
+}
+
+func formatMode(mode int64) string {
+	return fmt.Sprintf("%v", fs.FileMode(mode)&os.ModePerm)
+}
+
+func formatPtr(p *int64) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprint(*p)
 }


### PR DESCRIPTION
A custom version of 0.1.1 with two back-ported fixes from `main`.

Necessary because `main` currently cannot be used in Gadget. If this is useful, we'll deploy it as 0.1.2.