### PR TITLE
Fix removed objects in packs

### DIFF
--- a/internal/files/writer.go
+++ b/internal/files/writer.go
@@ -1,0 +1,165 @@
+package files
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gadget-inc/dateilager/internal/db"
+)
+
+func fileExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
+}
+
+func removePathIfSymlink(path string) error {
+	stat, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+
+	if stat.Mode()&os.ModeSymlink == os.ModeSymlink {
+		err = os.Remove(path)
+		return err
+	}
+
+	return nil
+}
+
+func removePathIfNotDirectory(path string) error {
+	stat, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+
+	if stat.Mode()&os.ModeDir != os.ModeDir {
+		err = os.Remove(path)
+		return err
+	}
+
+	return nil
+}
+
+func writeObject(rootDir string, reader *db.TarReader, header *tar.Header) error {
+	path := filepath.Join(rootDir, header.Name)
+
+	switch header.Typeflag {
+	case tar.TypeReg:
+		err := os.MkdirAll(filepath.Dir(path), 0777)
+		if err != nil {
+			return fmt.Errorf("mkdir -p %v: %w", filepath.Dir(path), err)
+		}
+
+		// os.OpenFile returns an error if it's called on a symlink
+		// remove any potential symlinks before writing the regular file
+		err = removePathIfSymlink(path)
+		if err != nil {
+			return fmt.Errorf("remove path if symlink %v: %w", path, err)
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+		if err != nil {
+			return fmt.Errorf("open file %v: %w", path, err)
+		}
+
+		err = reader.CopyContent(file)
+		file.Close()
+		if err != nil {
+			return fmt.Errorf("write %v to disk: %w", path, err)
+		}
+
+	case tar.TypeDir:
+		err := removePathIfNotDirectory(path)
+		if err != nil {
+			return fmt.Errorf("remove path if not dir %v: %w", path, err)
+		}
+
+		err = os.MkdirAll(path, os.FileMode(header.Mode))
+		if err != nil {
+			return fmt.Errorf("mkdir -p %v: %w", path, err)
+		}
+
+	case tar.TypeSymlink:
+		err := os.MkdirAll(filepath.Dir(path), 0755)
+		if err != nil {
+			return fmt.Errorf("mkdir -p %v: %w", filepath.Dir(path), err)
+		}
+
+		// Remove existing link
+		if _, err = os.Lstat(path); err == nil {
+			err = os.Remove(path)
+			if err != nil {
+				return fmt.Errorf("rm %v before symlinking %v: %w", path, header.Linkname, err)
+			}
+		}
+
+		err = os.Symlink(header.Linkname, path)
+		if err != nil {
+			return fmt.Errorf("ln -s %v %v: %w", header.Linkname, path, err)
+		}
+
+	case 'D':
+		err := os.Remove(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("remove %v from disk: %w", path, err)
+		}
+
+	default:
+		return fmt.Errorf("unhandle TAR type: %v", header.Typeflag)
+	}
+
+	return nil
+}
+
+func WriteTar(finalDir string, reader *db.TarReader, packPath *string) (uint32, error) {
+	var count uint32
+	dir := finalDir
+
+	if packPath != nil && fileExists(filepath.Join(finalDir, *packPath)) {
+		tmpDir, err := os.MkdirTemp("", "dateilager_pack_path_")
+		if err != nil {
+			return count, fmt.Errorf("cannot create tmp dir for packed tar: %w", err)
+		}
+		dir = tmpDir
+	}
+
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return count, fmt.Errorf("read next TAR header: %w", err)
+		}
+
+		err = writeObject(dir, reader, header)
+		if err != nil {
+			return count, err
+		}
+
+		count += 1
+	}
+
+	if packPath != nil && dir != finalDir {
+		path := filepath.Join(finalDir, *packPath)
+		err := os.RemoveAll(path)
+		if err != nil {
+			return count, fmt.Errorf("cannot remove existing packed path %v: %w", path, err)
+		}
+
+		err = os.Rename(filepath.Join(dir, *packPath), path)
+		if err != nil {
+			return count, fmt.Errorf("cannot rename packed path %v to %v: %w", filepath.Join(dir, *packPath), path, err)
+		}
+	}
+
+	return count, nil
+}

--- a/internal/pb/fs.proto
+++ b/internal/pb/fs.proto
@@ -92,6 +92,7 @@ message GetCompressResponse {
     int64 version = 1;
     Format format = 2;
     bytes bytes = 3;
+    optional string pack_path = 4;
 }
 
 message UpdateRequest {

--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -342,7 +342,7 @@ func (f *Fs) GetCompress(req *pb.GetCompressRequest, stream pb.Fs_GetCompressSer
 			}
 
 			for {
-				tar, err := tars()
+				tar, packPath, err := tars()
 				if err == io.EOF {
 					break
 				}
@@ -354,9 +354,10 @@ func (f *Fs) GetCompress(req *pb.GetCompressRequest, stream pb.Fs_GetCompressSer
 				}
 
 				err = stream.Send(&pb.GetCompressResponse{
-					Version: vrange.To,
-					Format:  pb.GetCompressResponse_S2_TAR,
-					Bytes:   tar,
+					Version:  vrange.To,
+					Format:   pb.GetCompressResponse_S2_TAR,
+					Bytes:    tar,
+					PackPath: packPath,
 				})
 				if err != nil {
 					return status.Errorf(codes.Internal, "FS send GetCompressResponse: %v", err)

--- a/test/client_combined_test.go
+++ b/test/client_combined_test.go
@@ -212,6 +212,7 @@ func TestCombinedWithPacked(t *testing.T) {
 	writePackedObjects(tc, 1, 1, nil, "a/", map[string]expectedObject{
 		"a/c": {content: "a/c v1"},
 		"a/d": {content: "a/d v1"},
+		"a/e": {content: "a/e v1"},
 	})
 	writeObject(tc, 1, 1, nil, "b", "b v1")
 
@@ -223,17 +224,19 @@ func TestCombinedWithPacked(t *testing.T) {
 
 	rebuild(tc, c, 1, nil, tmpDir, expectedResponse{
 		version: 1,
-		count:   3,
+		count:   4,
 	})
 
 	verifyDir(t, tmpDir, 1, map[string]expectedFile{
 		"a/c": {content: "a/c v1"},
 		"a/d": {content: "a/d v1"},
+		"a/e": {content: "a/e v1"},
 		"b":   {content: "b v1"},
 	})
 
 	updateStream := newMockUpdateServer(tc.Context(), 1, map[string]expectedObject{
 		"a/c": {content: "a/c v2"},
+		"a/e": {deleted: true},
 		"b":   {content: "b v2"},
 	})
 
@@ -244,7 +247,7 @@ func TestCombinedWithPacked(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, expectedResponse{
 		version: 2,
-		count:   3, // We updated one file in a pack so all of them were rebuilt
+		count:   3, // We updated a pack so all of them were rebuilt
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{


### PR DESCRIPTION
A bug that I noticed in DateiLager is that we did not properly support deleted files within packed objects.

Packed objects store and entire directory TAR as an object. Any change to the directory is stored as a new pack.

----

If we have a filesystem on disk, for example at version 3, and then we rebuild it to a newer version, say 5, DateiLager will send over a list of changes between those versions as a set of TARs.

When working with non packed files, we include all the new files as well as every file which was deleted. In parallel we write these new files and delete old ones.

However, when working with a packed object, we receive the entire directory as a TAR. If we write this to disk, as we're doing in `main`, we write every new file, but never clean up files which no longer exist in that pack.

Because the pack is a snapshot of the directory at that specific version, we do not know which files used to exist in older versions of that pack and should be deleted.

We could figure this out server side by unpacking every version of that packed object within the range and comparing them, but that would be quite slow.

-----

Instead the proposed strategy here is much simpler. When we rebuild a packed object, instead of writing it in place we write it to a temp directory and then move it into place by overwriting the previous version.

Because we're writing in a clean temp directory we end up with the correct state of the packed directory and move that correct directory into place.

We need to update the GRPC protocol to include a bit of packing information alongside the TARs.