### PR TITLE
Remove semicolon from sql query

### DIFF
--- a/internal/db/query.go
+++ b/internal/db/query.go
@@ -181,7 +181,7 @@ func buildQuery(project int64, vrange VersionRange, objectQuery *pb.ObjectQuery)
 		)
 		SELECT path, mode, size, bytes, packed, deleted
 		FROM updated_files
-		%s;
+		%s
 	`
 
 	query := fmt.Sprintf(sqlTemplate, bytesSelector, joinClause, pathPredicate, fetchDeleted)


### PR DESCRIPTION
This removes the semicolon `;` from the SQL query returned from our `buildQuery` function so that PGAnalyze can run `EXPLAIN` on it.

PGAnalyze fails to run `EXPLAIN` when a query contains a semicolon because it uses the following function to gather the explained data.

```plpgsql
DECLARE
  prepared_query text;
  prepared_params text;
  result text;
BEGIN
  SELECT regexp_replace(query, ';+s*Z', '') INTO prepared_query;
  IF prepared_query LIKE '%;%' THEN
    RAISE EXCEPTION 'cannot run EXPLAIN when query contains semicolon'; # <-- here
  END IF;

  IF array_length(params, 1) > 0 THEN
    SELECT string_agg(quote_literal(param) || '::unknown', ',') FROM unnest(params) p(param) INTO prepared_params;

    EXECUTE 'PREPARE pganalyze_explain AS ' || prepared_query;
    BEGIN
      EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || prepared_params || ')' INTO STRICT result;
    EXCEPTION WHEN OTHERS THEN
      DEALLOCATE pganalyze_explain;
      RAISE;
    END;
    DEALLOCATE pganalyze_explain;
  ELSE
    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) ' || prepared_query INTO STRICT result;
  END IF;

  RETURN result;
END
```