### PR TITLE
Use `Log` instead of `write`

### DIFF
--- a/internal/logger/grpc.go
+++ b/internal/logger/grpc.go
@@ -36,7 +36,7 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 		code := status.Code(err)
 
-		Write(ctx, grpc_zap.DefaultCodeToLevel(code), "finished unary call",
+		Log(ctx, grpc_zap.DefaultCodeToLevel(code), "finished unary call",
 			zap.Stringer("grpc.code", code),
 			zap.Duration("grpc.duration", duration),
 			zap.Error(err),
@@ -73,7 +73,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 
 		code := status.Code(err)
 
-		Write(ctx, grpc_zap.DefaultCodeToLevel(code), "finished streaming call",
+		Log(ctx, grpc_zap.DefaultCodeToLevel(code), "finished streaming call",
 			zap.Stringer("grpc.code", code),
 			zap.Duration("grpc.duration", duration),
 			zap.Error(err),

--- a/internal/logger/http.go
+++ b/internal/logger/http.go
@@ -33,7 +33,7 @@ func Middleware(next http.Handler) http.Handler {
 			lvl = zap.WarnLevel
 		}
 
-		Write(ctx, lvl, "finished request",
+		Log(ctx, lvl, "finished request",
 			zap.String("http.status", http.StatusText(ww.Status())),
 			zap.Int("http.code", ww.Status()),
 			zap.Duration("http.duration", duration),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -34,32 +34,40 @@ func Sync() error {
 }
 
 func Debug(ctx context.Context, msg string, fields ...zap.Field) {
-	Write(ctx, zapcore.DebugLevel, msg, fields...)
+	write(ctx, zapcore.DebugLevel, msg, fields...)
 }
 
 func Info(ctx context.Context, msg string, fields ...zap.Field) {
-	Write(ctx, zapcore.InfoLevel, msg, fields...)
+	write(ctx, zapcore.InfoLevel, msg, fields...)
 }
 
 func Warn(ctx context.Context, msg string, fields ...zap.Field) {
-	Write(ctx, zapcore.WarnLevel, msg, fields...)
+	write(ctx, zapcore.WarnLevel, msg, fields...)
 }
 
 func Error(ctx context.Context, msg string, fields ...zap.Field) {
-	Write(ctx, zapcore.ErrorLevel, msg, fields...)
+	write(ctx, zapcore.ErrorLevel, msg, fields...)
 }
 
 func Fatal(ctx context.Context, msg string, fields ...zap.Field) {
-	Write(ctx, zapcore.FatalLevel, msg, fields...)
+	write(ctx, zapcore.FatalLevel, msg, fields...)
 }
 
-func Write(ctx context.Context, level zapcore.Level, msg string, fields ...zap.Field) {
-	for _, hook := range hooks {
-		hook(ctx, level, msg, fields...)
-	}
-	Logger(ctx).Check(level, msg).Write(fields...)
+func Log(ctx context.Context, level zapcore.Level, msg string, fields ...zap.Field) {
+	write(ctx, level, msg, fields...)
 }
 
 func With(ctx context.Context, fields ...zap.Field) context.Context {
 	return context.WithValue(ctx, key, Logger(ctx).With(fields...))
+}
+
+// write is a helper function that writes the log entry.
+//
+// This function shouldn't be called directly because the logger is configured to skip two stack frames.
+// Instead, use one of the exported functions above.
+func write(ctx context.Context, level zapcore.Level, msg string, fields ...zap.Field) {
+	for _, hook := range hooks {
+		hook(ctx, level, msg, fields...)
+	}
+	Logger(ctx).Check(level, msg).Write(fields...)
 }


### PR DESCRIPTION
#82 fixed the `caller` field when we log outside of the `logger` package, however, it broke the `caller` field when we log inside the `logger` package. This fixes that.

**Before**
```
2022-09-12T21:19:35.766Z        INFO    go-grpc-middleware@v1.3.0/chain.go:49   finished streaming call {"grpc.service": "pb.Fs", "grpc.method": "Get", "grpc.code": "OK", "grpc.duration": "53.177375ms"}
```

**After**
```
2022-09-12T21:20:19.724Z        INFO    logger/grpc.go:76       finished streaming call {"grpc.service": "pb.Fs", "grpc.method": "Get", "grpc.code": "OK", "grpc.duration": "49.121125ms"}
```