### PR TITLE
Add pgx.QueryTracer

### DIFF
--- a/internal/telemetry/pgx.go
+++ b/internal/telemetry/pgx.go
@@ -1,0 +1,130 @@
+package telemetry
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func NewQueryTracer() pgx.QueryTracer {
+	return &pgxTracer{}
+}
+
+type pgxTracer struct{}
+
+// make sure the tracer implements the following interfaces
+var (
+	_ pgx.BatchTracer    = (*pgxTracer)(nil)
+	_ pgx.ConnectTracer  = (*pgxTracer)(nil)
+	_ pgx.CopyFromTracer = (*pgxTracer)(nil)
+	_ pgx.PrepareTracer  = (*pgxTracer)(nil)
+	_ pgx.QueryTracer    = (*pgxTracer)(nil)
+)
+
+func (t *pgxTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	return t.start(ctx, "pgx.query", conn.Config(), semconv.DBStatementKey.String(strings.Trim(data.SQL, " ")))
+}
+
+func (t *pgxTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData) {
+	t.end(ctx, data.Err, attribute.String("pgx.command-tag", data.CommandTag.String()))
+}
+
+func (t *pgxTracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchStartData) context.Context {
+	return t.start(ctx, "pgx.batch", conn.Config(), attribute.Int("pgx.batch.size", data.Batch.Len()))
+}
+
+func (t *pgxTracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchQueryData) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		semconv.DBStatementKey.String(strings.Trim(data.SQL, " ")),
+		attribute.String("pgx.command-tag", data.CommandTag.String()),
+	}
+
+	if data.Err != nil {
+		span.RecordError(data.Err, trace.WithAttributes(t.attrs(conn.Config(), attrs...)...))
+		span.SetStatus(codes.Error, data.Err.Error())
+	} else {
+		span.AddEvent("pgx.batch-query", trace.WithAttributes(t.attrs(conn.Config(), attrs...)...))
+	}
+}
+
+func (t *pgxTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchEndData) {
+	t.end(ctx, data.Err)
+}
+
+func (t *pgxTracer) TraceCopyFromStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromStartData) context.Context {
+	return t.start(ctx, "pgx.copy-from", conn.Config(),
+		semconv.DBSQLTableKey.String(data.TableName.Sanitize()),
+		attribute.StringSlice("db.sql.columns", data.ColumnNames),
+	)
+}
+
+func (t *pgxTracer) TraceCopyFromEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceCopyFromEndData) {
+	t.end(ctx, data.Err, attribute.String("pgx.command-tag", data.CommandTag.String()))
+}
+
+func (t *pgxTracer) TracePrepareStart(ctx context.Context, conn *pgx.Conn, data pgx.TracePrepareStartData) context.Context {
+	return t.start(ctx, "pgx.prepare", conn.Config(), semconv.DBStatementKey.String(strings.Trim(data.SQL, " ")))
+}
+
+func (t *pgxTracer) TracePrepareEnd(ctx context.Context, conn *pgx.Conn, data pgx.TracePrepareEndData) {
+	t.end(ctx, data.Err, attribute.Bool("pgx.already-prepared", data.AlreadyPrepared))
+}
+
+func (t *pgxTracer) TraceConnectStart(ctx context.Context, data pgx.TraceConnectStartData) context.Context {
+	return t.start(ctx, "pgx.connect", data.ConnConfig)
+}
+
+func (t *pgxTracer) TraceConnectEnd(ctx context.Context, data pgx.TraceConnectEndData) {
+	t.end(ctx, data.Err)
+}
+
+func (t *pgxTracer) attrs(config *pgx.ConnConfig, attributes ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.DBSystemPostgreSQL,
+		semconv.DBUserKey.String(config.User),
+		semconv.DBNameKey.String(config.Database),
+		semconv.NetPeerNameKey.String(config.Host),
+		semconv.NetPeerPortKey.Int(int(config.Port)),
+	}
+
+	if len(attributes) > 0 {
+		attrs = append(attrs, attributes...)
+	}
+
+	return attrs
+}
+
+func (t *pgxTracer) start(ctx context.Context, name string, config *pgx.ConnConfig, attrs ...attribute.KeyValue) context.Context {
+	if !trace.SpanFromContext(ctx).IsRecording() {
+		return ctx
+	}
+
+	ctx, _ = Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(t.attrs(config, attrs...)...),
+	)
+
+	return ctx
+}
+
+func (t *pgxTracer) end(ctx context.Context, err error, attrs ...attribute.KeyValue) {
+	span := trace.SpanFromContext(ctx)
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -45,7 +46,9 @@ func NewDbPoolConnector(ctx context.Context, uri string) (*DbPoolConnector, erro
 		return nil, err
 	}
 
-	config.ConnConfig.Tracer = telemetry.NewQueryTracer()
+	if os.Getenv("DL_PGX_TRACING") == "1" {
+		config.ConnConfig.Tracer = telemetry.NewQueryTracer()
+	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {


### PR DESCRIPTION
This adds tracing to `pgx` by implementing the `pgx.QueryTracer` interface. This allows us to trace all database calls to postgres.

It's fairly verbose because of all the db calls we make... but I think it's worth it while we investigate our timeout issues. We can add a flag/envVar to determine if we should enable these traces in a future PR.

Here are some example traces:
- [`make client-get`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/7P6qbzLR3M5/trace/CWZ3w5f2n1Z?fields[]=c_name&fields[]=c_service.name&span=7ac961d081e6f852)
- [`make client-large-update`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/4Gf7WTw3Qgz/trace/iZzPpsv1cFc?fields[]=c_name&fields[]=c_service.name&span=f40d397d9c504b8c)
- [`make client-rebuild dir=rebuild`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/futbUwuHEb3/trace/dciRnd14rdS?fields[]=c_name&fields[]=c_service.name&span=6698606cccdf943d)