### PR TITLE
Tracing cleanup

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -162,7 +162,7 @@ func Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) 
 	return tracer.Start(ctx, spanName, opts...)
 }
 
-func Wrap(ctx context.Context, spanName string, fn func(context.Context, trace.Span) error) error {
+func Trace(ctx context.Context, spanName string, fn func(context.Context, trace.Span) error) error {
 	ctx, span := Start(ctx, spanName)
 	defer span.End()
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -332,7 +332,7 @@ func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVe
 		return -1, diffCount, err
 	}
 
-	_, err = DiffAndSummarize(dir)
+	_, err = DiffAndSummarize(ctx, dir)
 	if err != nil {
 		return -1, diffCount, err
 	}
@@ -352,7 +352,7 @@ func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int
 		return -1, 0, err
 	}
 
-	diff, err := DiffAndSummarize(dir)
+	diff, err := DiffAndSummarize(rootCtx, dir)
 	if err != nil {
 		return -1, 0, err
 	}

--- a/pkg/client/dir.go
+++ b/pkg/client/dir.go
@@ -1,14 +1,18 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/telemetry"
 	fsdiff "github.com/gadget-inc/fsdiff/pkg/diff"
 	fsdiff_pb "github.com/gadget-inc/fsdiff/pkg/pb"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const metadataDir = ".dl"
@@ -60,7 +64,10 @@ func WriteVersionFile(dir string, version int64) error {
 	return nil
 }
 
-func DiffAndSummarize(dir string) (*fsdiff_pb.Diff, error) {
+func DiffAndSummarize(ctx context.Context, dir string) (*fsdiff_pb.Diff, error) {
+	_, span := telemetry.Start(ctx, "diff-and-summarize", trace.WithAttributes(key.Directory.Attribute(dir)))
+	defer span.End()
+
 	err := ensureMetadataDir(dir)
 	if err != nil {
 		return nil, err

--- a/test/shared_test.go
+++ b/test/shared_test.go
@@ -222,7 +222,7 @@ func writeTmpFiles(t *testing.T, version int64, files map[string]string) string 
 	err = client.WriteVersionFile(dir, version)
 	require.NoError(t, err, "write version file")
 
-	_, err = client.DiffAndSummarize(dir)
+	_, err = client.DiffAndSummarize(context.Background(), dir)
 	require.NoError(t, err, "diff and summarize")
 
 	return dir


### PR DESCRIPTION
This is an optional follow-up to #87 that removes some redundant traces and adds a trace to `DiffAndSummarize` because it takes a while and leaves a large gap in Honeycomb. I recommend hiding whitespace when looking at the file changes.

Here are some example traces:
- [`make client-get`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/mNoy95mAobC/trace/xzozgAB15ZG?fields[]=c_name&fields[]=c_service.name&span=6acee00a06ee9d6f)
- [`make client-large-update`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/A3ShxVWg4Ca/trace/mC8ej3LTMeV?fields[]=c_name&fields[]=c_service.name&span=87ab806156fe81a6)
- [`make client-rebuild dir=rebuild`](https://ui.honeycomb.io/gadget/datasets/gadget-development/result/4qhhrWYHWJ3/trace/o8LiErsCZdb?fields[]=c_name&fields[]=c_service.name&span=0452c745969c1326)