### PR TITLE
Ensure consistent ordering for packed objects

### DIFF
--- a/internal/db/tar.go
+++ b/internal/db/tar.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/gadget-inc/dateilager/internal/pb"
 	"github.com/klauspost/compress/s2"
@@ -182,6 +183,8 @@ func updateObjects(before []byte, updates []*pb.Object) ([]byte, []byte, error) 
 
 	reader := NewTarReader(before)
 	readerObjectsRemaining := true
+
+	sort.Slice(updates, func(i, j int) bool { return updates[i].Path < updates[j].Path })
 
 	stream := func() (*pb.Object, error) {
 		// Yield unseen updates as new objects if we've finished walking the original pack

--- a/pkg/cli/new.go
+++ b/pkg/cli/new.go
@@ -23,7 +23,12 @@ func NewCmdNew() *cobra.Command {
 
 			client := client.FromContext(ctx)
 
-			err := client.NewProject(ctx, id, &template, patterns)
+			var templatePtr *int64
+			if template != -1 {
+				templatePtr = &template
+			}
+
+			err := client.NewProject(ctx, id, templatePtr, patterns)
 			if err != nil {
 				return fmt.Errorf("could not create new project: %w", err)
 			}


### PR DESCRIPTION
I discovered this while working on the recent DL slowdown.

We were not properly ensuring that a directory with the same files would always pack in the same order - and result in the same hash key. We intrinsically relied on the order the files were provided to us by the client.

`fsdiff` provides the files to us in an ordered fashion, but when we updated the client to upload files in parallel that ordering was no longer guaranteed on the server side.

This changes ensure the updates are once again ordered and adds a test to verify that this is the case.