### PR TITLE
Recover from arbitrary errors writing files by removing the thing we're about to write

### DIFF
--- a/test/shared_test.go
+++ b/test/shared_test.go
@@ -284,6 +284,7 @@ func verifyDir(t *testing.T, dir string, version int64, files map[string]expecte
 			path = fmt.Sprintf("%s/", path)
 		}
 		info := dirEntries[path]
+		require.True(t, info != nil, "can't verify, no file found at expected path %v", path)
 
 		switch file.fileType {
 		case typeDirectory:


### PR DESCRIPTION
I encountered a sequence of changes that DL didn't expect where I was creating a symlink at a path that was previously a folder full of files. There's a bunch of other annoying cases like this, where we should be able to go from any state on disk to any new incoming object type.

 The existing strategy did a bit of checking to see if stuff wasn't quite right, but I think we aught to be a bit more robust. The recovery strategy is always the same if we have a new incoming object: delete whatever is there so we can just write the new thing on top. If we're gonna do that, I think we can do it a bit more blindly. 

Instead of checking ahead of time for erroneous conditions (which also requires another syscall every write), we just blindly try to do the thing we need to do, and if it fails, remove whatever is there and try again. That way, we don't need to anticipate whatever fucked up case is on disk at the time and instead just blow it away. I also like this because it makes the fast path a bit faster where we do less checking up front and just let the kernel tell us we're doing something weird.