### PR TITLE
Add `eslint.workingDirectories` to settings.example.json

### DIFF
--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,6 +1,5 @@
 {
-    "go.lintTool":"golangci-lint",
-    "go.lintFlags": [
-        "--fast"
-    ]
+  "eslint.workingDirectories": ["./js"],
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": ["--fast"]
 }


### PR DESCRIPTION
Adding `"eslint.workingDirectories": ["./js"]` to your `vscode/settings.json` will resolve the eslint error in vscode.

This adds that config to our `vscode/settings.example.json`