### PR TITLE
Tighten remove object CTE

### DIFF
--- a/internal/db/queryBuilder.go
+++ b/internal/db/queryBuilder.go
@@ -96,7 +96,7 @@ func (qb *queryBuilder) removedObjectsCTE() string {
 		SELECT o.path, o.mode, 0 AS size, ''::bytea as bytes, o.packed, true AS deleted, null::hash as hash
 		FROM possible_objects o
 		WHERE o.project = __project__
-		  AND o.start_version <= __stop_version__
+		  AND o.start_version <= __start_version__
 		  AND o.stop_version > __start_version__
 		  AND o.stop_version <= __stop_version__
 		  %s


### PR DESCRIPTION
When calculating the files to remove we were looking at far too many objects.

We only need to consider files that already existed on disk, so that have a `start_version` less than our lower bound start version.

I suspect this was a typo when building the `queryBuilder`.

Most of the time this would not cause issues but it did if you added a file then directory of files with that name.