### PR TITLE
Add retry policy to our clients

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,6 +99,22 @@ func NewClient(ctx context.Context, server string, opts ...func(*options)) (*Cli
 		),
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+		grpc.WithDefaultServiceConfig(`
+			{
+				"methodConfig": [
+					{
+						"name": [{"service": "pb.Fs"}],
+						"retryPolicy": {
+							"maxAttempts": 2,
+							"initialBackoff": "0.1s",
+							"maxBackoff": "1s",
+							"backoffMultiplier": 1.5,
+							"retryableStatusCodes": [ "UNAVAILABLE", "INTERNAL", "DEADLINE_EXCEEDED" ]
+						}
+					}
+				]
+			}
+		`),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Following the docs to create a service config, which is how you introduce a retry policy.

However, I cannot get this to work in any of my testing 😢 

Following almost exactly the example from the GRPC-Go library: https://github.com/grpc/grpc-go/tree/c44f627fd1f65c4e9f2837c17b4a734c516172fd/examples/features/retry

And from the other docs: https://github.com/grpc/grpc/blob/master/doc/service_config.md

But this does not seem to retry in my testing.