### PR TITLE
Fixed array hash

### DIFF
--- a/internal/db/content.go
+++ b/internal/db/content.go
@@ -13,22 +13,22 @@ import (
 )
 
 type Hash struct {
-	H1 []byte
-	H2 []byte
+	H1 [16]byte
+	H2 [16]byte
 }
 
 func HashContent(data []byte) Hash {
 	sha := sha256.Sum256(data)
 	return Hash{
-		H1: sha[0:16],
-		H2: sha[16:32],
+		H1: *(*[16]byte)(sha[0:16]),
+		H2: *(*[16]byte)(sha[16:32]),
 	}
 }
 
 func (h *Hash) Bytes() []byte {
-	hash := make([]byte, 32)
-	copy(hash[0:16], h.H1)
-	copy(hash[16:], h.H2)
+	var hash []byte
+	hash = append(hash, h.H1[:]...)
+	hash = append(hash, h.H2[:]...)
 	return hash
 }
 
@@ -109,13 +109,13 @@ func RandomContents(ctx context.Context, tx pgx.Tx, sample float32) ([]Hash, err
 	var hashes []Hash
 
 	for rows.Next() {
-		var h1, h2 []byte
-		err = rows.Scan(&h1, &h2)
+		var hash Hash
+		err = rows.Scan(&hash.H1, &hash.H2)
 		if err != nil {
 			return nil, fmt.Errorf("random contents scan: %w", err)
 		}
 
-		hashes = append(hashes, Hash{H1: h1, H2: h2})
+		hashes = append(hashes, hash)
 	}
 
 	return hashes, nil

--- a/internal/db/queryBuilder.go
+++ b/internal/db/queryBuilder.go
@@ -102,7 +102,7 @@ func (qb *queryBuilder) updatedObjectsCTE() string {
 			       ON h.hash = o.hash`
 	}
 
-	hashSelector := "null::hash as hash"
+	hashSelector := "'(00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000)'::hash as hash"
 	if qb.includeHashes {
 		hashSelector = "o.hash"
 	}
@@ -126,7 +126,7 @@ func (qb *queryBuilder) updatedObjectsCTE() string {
 
 func (qb *queryBuilder) removedObjectsCTE() string {
 	template := `
-			SELECT o.path, o.mode, 0 AS size, ''::bytea AS bytes, o.packed, true AS deleted, null::hash AS hash
+			SELECT o.path, o.mode, 0 AS size, ''::bytea AS bytes, o.packed, true AS deleted, '(00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000)'::hash AS hash
 			FROM possible_objects o
 			WHERE o.project = __project__
 			AND o.start_version <= __start_version__

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -164,7 +163,7 @@ func UpdatePackedObjects(ctx context.Context, tx pgx.Tx, project int64, version 
 
 	newHash := HashContent(updated)
 
-	if bytes.Equal(hash.H1, newHash.H1) && bytes.Equal(hash.H2, newHash.H2) {
+	if hash == newHash {
 		// content didn't change
 		return false, nil
 	}


### PR DESCRIPTION
Change the `Hash` type from containing two slices (references to variable length arrays) to containing two fixed sized arrays.

This reduces a lot of pointer indirection by storing all of the data within the struct itself.

And, the reason I kicked off this PR, is that it allows you to directly compare two hashes `hash1 == hash2` instead of using `bytes.Equal` like we used to.

This built in equality check is useful because it will allow us to use `Hash` as a map key type. (https://golangbyexample.com/allowed-key-and-value-types-golang/)

However, this does mean we no longer support `nil` hashes, so our `queryBuilder` needs to return a 0 hash instead of `null` for cases when hashes don't make sense (for example with deleted objects).