### PR TITLE
Add initial fuzz testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,17 @@ jobs:
       - run: nix develop -c make build
       - run: nix develop -c make test
 
+  test-fuzz:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-env
+      - run: nix develop -c dev &
+      - run: nix develop -c make build
+      - run: nix develop -c make setup-local
+      - run: nix develop -c make server &
+      - run: nix develop -c make test-fuzz
+
   test-js:
     runs-on: ubuntu-20.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ PROTO_TS_FILES := $(shell find js/src/pb -type f -name '*.ts')
 MIGRATE_DIR := ./migrations
 SERVICE := $(PROJECT).server
 
-.PHONY: install migrate migrate-create clean build release test test-one test-js lint-js typecheck-js
+.PHONY: install migrate migrate-create clean build release
+.PHONY: test test-one test-fuzz test-js lint-js typecheck-js
 .PHONY: reset-db setup-local server server-profile js-install
 .PHONY: client-update client-large-update client-get client-rebuild client-pack
 .PHONY: client-gc-contents client-gc-project client-gc-random-projects
@@ -116,6 +117,11 @@ ifndef name
 else
 	cd test && go test -run $(name)
 endif
+
+test-fuzz: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+test-fuzz: export DL_SKIP_SSL_VERIFICATION=1
+test-fuzz: reset-db
+	go run cmd/fuzz-test/main.go --server $(GRPC_SERVER) --iterations 1000 --projects 5
 
 test-js: js-install
 	cd js && npm run test

--- a/cmd/fuzz-test/main.go
+++ b/cmd/fuzz-test/main.go
@@ -1,0 +1,652 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	stdlog "log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gadget-inc/dateilager/internal/logger"
+	dlc "github.com/gadget-inc/dateilager/pkg/client"
+	"github.com/gadget-inc/dateilager/pkg/version"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	charset = "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ0123456789"
+)
+
+type Type int
+
+const (
+	typeMissing Type = iota
+	typeRegular
+	typeDirectory
+	typeSymlink
+)
+
+var (
+	Join = filepath.Join
+	// The default filesystem on MacOS is not case sensitive
+	// and in that case we need to be more careful when checking if an object exists
+	IsCaseSensitiveFs = runtime.GOOS != "darwin"
+)
+
+func typeStr(type_ Type) string {
+	switch type_ {
+	case typeMissing:
+		return "missing"
+	case typeRegular:
+		return "file"
+	case typeDirectory:
+		return "directory"
+	case typeSymlink:
+		return "symlink"
+	default:
+		panic(fmt.Sprintf("unknown type: %d", type_))
+	}
+}
+
+func randString(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func trimDir(path, dir string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(path, dir), "/")
+}
+
+func projectDir(base string, project int64) string {
+	return filepath.Join(base, fmt.Sprint(project))
+}
+
+func walkDir(dir string) map[string]Type {
+	objects := make(map[string]Type, 10)
+
+	err := filepath.Walk(dir, func(fullPath string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		path := trimDir(fullPath, dir)
+		if strings.HasPrefix(path, ".dl") || path == "" {
+			return nil
+		}
+
+		switch {
+		case info.Mode()&fs.ModeSymlink == fs.ModeSymlink:
+			objects[path] = typeSymlink
+		case info.IsDir():
+			objects[path] = typeDirectory
+		default:
+			objects[path] = typeRegular
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		logger.Fatal(context.Background(), "cannot walk directory", zap.String("dir", dir), zap.Error(err))
+	}
+
+	return objects
+}
+
+func objectFilter(objects map[string]Type, type_ Type) []string {
+	var files []string
+	for path, objectType := range objects {
+		if objectType == type_ {
+			files = append(files, path)
+		}
+	}
+	return files
+}
+
+func objectExists(objects map[string]Type, project int64, path string) bool {
+	withoutProject := trimDir(path, fmt.Sprint(project))
+
+	if IsCaseSensitiveFs {
+		_, ok := objects[withoutProject]
+		return ok
+	} else {
+		withoutProject = strings.ToLower(withoutProject)
+		for path := range objects {
+			if strings.ToLower(path) == withoutProject {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+type Operation interface {
+	Apply() error
+	String() string
+}
+
+type SkipOp struct{}
+
+func (o SkipOp) Apply() error {
+	return nil
+}
+
+func (o SkipOp) String() string {
+	return "Skip()"
+}
+
+type AddFileOp struct {
+	base    string
+	dir     string
+	name    string
+	content []byte
+}
+
+func newAddFileOp(base string, project int64) Operation {
+	dir := fmt.Sprint(project)
+	name := randString(rand.Intn(20) + 1)
+	objects := walkDir(Join(base, dir))
+
+	dirs := objectFilter(objects, typeDirectory)
+	if len(dirs) > 0 && rand.Intn(2) == 1 {
+		dir = Join(dir, dirs[rand.Intn(len(dirs))])
+	}
+
+	if objectExists(objects, project, Join(dir, name)) {
+		return SkipOp{}
+	}
+
+	return AddFileOp{
+		base:    base,
+		dir:     dir,
+		name:    name,
+		content: []byte(randString(rand.Intn(500))),
+	}
+}
+
+func (o AddFileOp) Apply() error {
+	return os.WriteFile(Join(o.base, o.dir, o.name), o.content, 0755)
+}
+
+func (o AddFileOp) String() string {
+	return fmt.Sprintf("AddFileOp(%s, %d)", Join(o.dir, o.name), len(o.content))
+}
+
+type UpdateFileOp struct {
+	base    string
+	dir     string
+	name    string
+	content []byte
+}
+
+func newUpdateFileOp(base string, project int64) Operation {
+	dir := fmt.Sprint(project)
+	files := objectFilter(walkDir(Join(base, dir)), typeRegular)
+
+	if len(files) == 0 {
+		return SkipOp{}
+	}
+
+	return AddFileOp{
+		base:    base,
+		dir:     dir,
+		name:    files[rand.Intn(len(files))],
+		content: []byte(randString(rand.Intn(500))),
+	}
+}
+
+func (o UpdateFileOp) Apply() error {
+	return os.WriteFile(filepath.Join(o.base, o.dir, o.name), o.content, 0755)
+}
+
+func (o UpdateFileOp) String() string {
+	return fmt.Sprintf("UpdateFileOp(%s, %d)", Join(o.dir, o.name), len(o.content))
+}
+
+type AddDirOp struct {
+	base string
+	dir  string
+	name string
+}
+
+func newAddDirOp(base string, project int64) Operation {
+	dir := fmt.Sprint(project)
+	name := randString(rand.Intn(20) + 1)
+	objects := walkDir(Join(base, dir))
+
+	dirs := objectFilter(objects, typeDirectory)
+	if rand.Intn(10) < 1 {
+		dir = Join(dir, fmt.Sprintf("pack%d", rand.Intn(2)+1))
+	} else if len(dirs) > 0 && rand.Intn(2) == 1 {
+		dir = Join(dir, dirs[rand.Intn(len(dirs))])
+	}
+
+	if objectExists(objects, project, Join(dir, name)) {
+		return SkipOp{}
+	}
+
+	return AddDirOp{
+		base: base,
+		dir:  dir,
+		name: name,
+	}
+}
+
+func (o AddDirOp) Apply() error {
+	return os.MkdirAll(Join(o.base, o.dir, o.name), 0755)
+}
+
+func (o AddDirOp) String() string {
+	return fmt.Sprintf("AddDirOp(%s)", Join(o.dir, o.name))
+}
+
+type RemoveFileOp struct {
+	base string
+	dir  string
+	name string
+}
+
+func newRemoveFileOp(base string, project int64) Operation {
+	dir := fmt.Sprint(project)
+	files := objectFilter(walkDir(Join(base, dir)), typeRegular)
+
+	if len(files) == 0 {
+		return SkipOp{}
+	}
+
+	return RemoveFileOp{
+		base: base,
+		dir:  dir,
+		name: files[rand.Intn(len(files))],
+	}
+}
+
+func (o RemoveFileOp) Apply() error {
+	return os.Remove(Join(o.base, o.dir, o.name))
+}
+
+func (o RemoveFileOp) String() string {
+	return fmt.Sprintf("RemoveFileOp(%s)", Join(o.dir, o.name))
+}
+
+type AddSymlinkOp struct {
+	base   string
+	dir    string
+	name   string
+	target string
+}
+
+func newAddSymlinkOp(base string, project int64) Operation {
+	dir := fmt.Sprint(project)
+	name := randString(rand.Intn(20) + 1)
+	objects := walkDir(Join(base, dir))
+
+	dirs := objectFilter(objects, typeDirectory)
+	files := objectFilter(objects, typeRegular)
+
+	if len(files) == 0 {
+		return SkipOp{}
+	}
+
+	if len(dirs) > 0 && rand.Intn(2) == 1 {
+		dir = Join(dir, dirs[rand.Intn(len(dirs))])
+	}
+
+	if objectExists(objects, project, Join(dir, name)) {
+		return SkipOp{}
+	}
+
+	return AddSymlinkOp{
+		base:   base,
+		dir:    dir,
+		name:   name,
+		target: files[rand.Intn(len(files))],
+	}
+}
+
+func (o AddSymlinkOp) Apply() error {
+	return os.Symlink(Join(o.base, o.dir, o.target), Join(o.base, o.dir, o.name))
+}
+
+func (o AddSymlinkOp) String() string {
+	return fmt.Sprintf("AddSymlinkOp(%s, %s)", Join(o.dir, o.target), Join(o.dir, o.name))
+}
+
+type OpConstructor func(dir string, project int64) Operation
+
+var opConstructors = []OpConstructor{newAddFileOp, newUpdateFileOp, newAddDirOp, newRemoveFileOp, newAddSymlinkOp}
+
+func randomOperation(baseDir string, project int64) Operation {
+	var operation Operation = SkipOp{}
+
+	for {
+		operation = opConstructors[rand.Intn(len(opConstructors))](baseDir, project)
+		if _, isSkip := operation.(SkipOp); !isSkip {
+			break
+		}
+	}
+
+	return operation
+}
+
+func createDirs(projects int) (string, string, string, string, error) {
+	var dirs []string
+
+	for _, name := range []string{"base", "continue", "reset", "step"} {
+		dir, err := os.MkdirTemp("", fmt.Sprintf("dl-ft-%s-", name))
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("cannot create tmp dir: %w", err)
+		}
+
+		for projectIdx := 1; projectIdx <= projects; projectIdx++ {
+			err = os.MkdirAll(filepath.Join(dir, fmt.Sprint(projectIdx)), 0755)
+			if err != nil {
+				return "", "", "", "", fmt.Errorf("cannot create project dir: %w", err)
+			}
+		}
+		dirs = append(dirs, dir)
+	}
+
+	return dirs[0], dirs[1], dirs[2], dirs[3], nil
+}
+
+func runIteration(ctx context.Context, client *dlc.Client, project int64, operation Operation, baseDir, continueDir, resetDir, stepDir string) error {
+	err := operation.Apply()
+	if err != nil {
+		return fmt.Errorf("failed to apply operation %s: %w", operation.String(), err)
+	}
+
+	version, _, err := client.Update(ctx, project, projectDir(baseDir, project))
+	if err != nil {
+		return fmt.Errorf("failed to update project %d: %w", project, err)
+	}
+
+	_, _, err = client.Rebuild(ctx, project, "", nil, projectDir(continueDir, project), "")
+	if err != nil {
+		return fmt.Errorf("failed to rebuild continue project %d: %w", project, err)
+	}
+
+	os.RemoveAll(projectDir(resetDir, project))
+	err = os.MkdirAll(projectDir(resetDir, project), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create reset dir %s: %w", projectDir(resetDir, project), err)
+	}
+
+	_, _, err = client.Rebuild(ctx, project, "", nil, projectDir(resetDir, project), "")
+	if err != nil {
+		return fmt.Errorf("failed to rebuild reset project %d: %w", project, err)
+	}
+
+	os.RemoveAll(projectDir(stepDir, project))
+	err = os.MkdirAll(projectDir(stepDir, project), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create step dir %s: %w", projectDir(stepDir, project), err)
+	}
+
+	stepVersion := int64(rand.Intn(int(version)))
+	_, _, err = client.Rebuild(ctx, project, "", &stepVersion, projectDir(stepDir, project), "")
+	if err != nil {
+		return fmt.Errorf("failed to rebuild step project %d: %w", project, err)
+	}
+	_, _, err = client.Rebuild(ctx, project, "", &version, projectDir(stepDir, project), "")
+	if err != nil {
+		return fmt.Errorf("failed to rebuild step project %d: %w", project, err)
+	}
+
+	return nil
+}
+
+type MatchError struct {
+	project         int64
+	path            string
+	expectedType    Type
+	actualType      Type
+	expectedContent string
+	actualContent   string
+}
+
+func compareDirs(project int64, expected string, actual string) ([]MatchError, error) {
+	var errors []MatchError
+
+	expectedObjects := walkDir(expected)
+	actualObjects := walkDir(actual)
+
+	for path, expectedType := range expectedObjects {
+		actualType, found := actualObjects[path]
+		if !found {
+			errors = append(errors, MatchError{
+				project:      project,
+				path:         path,
+				expectedType: expectedType,
+				actualType:   -1,
+			})
+			continue
+		}
+
+		if expectedType != actualType {
+			errors = append(errors, MatchError{
+				project:      project,
+				path:         path,
+				expectedType: expectedType,
+				actualType:   actualType,
+			})
+			continue
+		}
+
+		if expectedType == typeRegular {
+			expectedContent, err := os.ReadFile(filepath.Join(expected, path))
+			if err != nil {
+				return nil, err
+			}
+			actualContent, err := os.ReadFile(filepath.Join(actual, path))
+			if err != nil {
+				return nil, err
+			}
+
+			if string(expectedContent) != string(actualContent) {
+				errors = append(errors, MatchError{
+					project:         project,
+					path:            path,
+					expectedType:    expectedType,
+					actualType:      actualType,
+					expectedContent: string(expectedContent),
+					actualContent:   string(actualContent),
+				})
+			}
+		}
+	}
+
+	for path, actualType := range actualObjects {
+		_, found := expectedObjects[path]
+		if !found {
+			errors = append(errors, MatchError{
+				project:      project,
+				path:         path,
+				expectedType: -1,
+				actualType:   actualType,
+			})
+		}
+	}
+
+	return errors, nil
+}
+
+func logMatchErrors(ctx context.Context, matchErrors []MatchError) {
+	for _, matchErr := range matchErrors {
+		props := []zapcore.Field{zap.Int("project", int(matchErr.project)), zap.String("path", matchErr.path)}
+
+		switch {
+		case matchErr.expectedType == -1:
+			logger.Info(ctx, "missing file in target dir", props...)
+		case matchErr.actualType == -1:
+			logger.Info(ctx, "missing file in source dir", props...)
+		case matchErr.expectedType != matchErr.actualType:
+			props = append(props, zap.String("expected", typeStr(matchErr.expectedType)), zap.String("actual", typeStr(matchErr.actualType)))
+			logger.Info(ctx, "object type mismatch", props...)
+		case matchErr.expectedContent != matchErr.actualContent:
+			props = append(props, zap.String("expected", matchErr.expectedContent), zap.String("actual", matchErr.actualContent))
+			logger.Info(ctx, "object content mismatch", props...)
+		}
+	}
+}
+
+func logOpLog(ctx context.Context, opLog []Operation) {
+	for idx, operation := range opLog {
+		logger.Info(ctx, "operation", zap.Int("idx", idx), zap.String("op", operation.String()))
+	}
+}
+
+func verifyDirs(ctx context.Context, projects int, baseDir, continueDir, resetDir, stepDir string) error {
+	for projectIdx := 1; projectIdx <= projects; projectIdx++ {
+		project := int64(projectIdx)
+
+		matchErrors, err := compareDirs(project, projectDir(baseDir, project), projectDir(resetDir, project))
+		if err != nil {
+			return fmt.Errorf("failed to compare base & reset dirs: %w", err)
+		}
+		if len(matchErrors) > 0 {
+			logMatchErrors(ctx, matchErrors)
+			return errors.New("reset directory match error")
+		}
+
+		matchErrors, err = compareDirs(project, projectDir(baseDir, project), projectDir(continueDir, project))
+		if err != nil {
+			return fmt.Errorf("failed to compare base & continue dirs: %w", err)
+		}
+		if len(matchErrors) > 0 {
+			logMatchErrors(ctx, matchErrors)
+			return errors.New("continue directory match error")
+		}
+
+		matchErrors, err = compareDirs(project, projectDir(baseDir, project), projectDir(stepDir, project))
+		if err != nil {
+			return fmt.Errorf("failed to compare base & step dirs: %w", err)
+		}
+		if len(matchErrors) > 0 {
+			logMatchErrors(ctx, matchErrors)
+			return errors.New("step directory match error")
+		}
+	}
+	return nil
+}
+
+func fuzzTest(ctx context.Context, client *dlc.Client, projects, iterations int) error {
+	logger.Info(ctx, "starting fuzz test", zap.Int("projects", projects), zap.Int("iterations", iterations))
+
+	for projectIdx := 1; projectIdx <= projects; projectIdx++ {
+		pattern := "^pack1/.*/,^pack2/.*/"
+		err := client.NewProject(ctx, int64(projectIdx), nil, &pattern)
+		if err != nil {
+			return err
+		}
+	}
+
+	baseDir, continueDir, resetDir, stepDir, err := createDirs(projects)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(baseDir)
+	defer os.RemoveAll(continueDir)
+	defer os.RemoveAll(resetDir)
+	defer os.RemoveAll(stepDir)
+
+	var opLog []Operation
+
+	for iterIdx := 0; iterIdx < iterations; iterIdx++ {
+		project := int64(rand.Intn(projects) + 1)
+
+		operation := randomOperation(baseDir, project)
+		opLog = append(opLog, operation)
+
+		err := runIteration(ctx, client, project, operation, baseDir, continueDir, resetDir, stepDir)
+		if err != nil {
+			return fmt.Errorf("failed to run iteration %d: %w", iterIdx, err)
+		}
+
+		err = verifyDirs(ctx, projects, baseDir, continueDir, resetDir, stepDir)
+		if err != nil {
+			logOpLog(ctx, opLog)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newCommand() *cobra.Command {
+	var (
+		projects   int
+		iterations int
+		server     string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "fuzz",
+		Short:   "DateiLager fuzz testing",
+		Version: version.Version,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true // silence usage when an error occurs after flags have been parsed
+
+			ctx := cmd.Context()
+
+			client, err := dlc.NewClient(ctx, server)
+			if err != nil {
+				return err
+			}
+
+			return fuzzTest(ctx, client, projects, iterations)
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.IntVar(&projects, "projects", 5, "How many projects to create")
+	flags.IntVar(&iterations, "iterations", 1000, "How many FS operations to apply")
+	flags.StringVar(&server, "server", "", "Server GRPC address")
+
+	return cmd
+}
+
+func main() {
+	ctx := context.Background()
+	cmd := newCommand()
+
+	err := logger.Init(zap.Config{
+		Level:       zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		Development: true,
+		Encoding:    "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:       "",
+			LevelKey:      "",
+			NameKey:       "",
+			CallerKey:     "",
+			MessageKey:    "M",
+			StacktraceKey: "",
+		},
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+	})
+	if err != nil {
+		stdlog.Fatal("failed to init logger", err)
+	}
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	err = cmd.ExecuteContext(ctx)
+	if err != nil {
+		logger.Fatal(ctx, "fuzz test failed", zap.Error(err))
+	}
+
+	logger.Info(ctx, "fuzz test completed")
+	_ = logger.Sync()
+}

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   version = "0.3.4";
   src = ./.;
   proxyVendor = true; # Fixes: cannot query module due to -mod=vendor running make install
-  vendorSha256 = "sha256-CDEw29WvbKEfC4RZiwPQXl8i8rz7RqR2LWw6eBQ79u0=";
+  vendorSha256 = "sha256-s0mChRHEwRkK1Gc8IioWbRMJoVAexNTA9y6WeTl41ZM=";
 
   outputs = [ "out" "client" "server" "webui" "assets" "migrations" ];
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gadget-inc/dateilager
 go 1.18
 
 require (
-	github.com/gadget-inc/fsdiff v0.4.3
+	github.com/gadget-inc/fsdiff v0.4.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jackc/pgx/v5 v5.0.2

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/gadget-inc/fsdiff v0.4.3 h1:7l3IiEghgNiXQBXzceLX4V27XzjoAsc4v7Ajj9Jj4CM=
-github.com/gadget-inc/fsdiff v0.4.3/go.mod h1:GJurAL/F4qq4hp7uLc7nhqu9PbszI4/7fkTAUNa/VIY=
+github.com/gadget-inc/fsdiff v0.4.4 h1:hLl/rCcWmW3P27LqMEyT2LVNWDLsREqsncODECH1vNw=
+github.com/gadget-inc/fsdiff v0.4.4/go.mod h1:GJurAL/F4qq4hp7uLc7nhqu9PbszI4/7fkTAUNa/VIY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=


### PR DESCRIPTION
This is the first version of the DL fuzz testing tool. Still lots of room for improvements.

This script creates N projects and a filesystem for each one. Then it begins applying operations to this filesystem, and after each operation it:

- Updates the FS in DateiLager
- Rebuilds the FS from scratch
- Rebuilds the FS from the latest-1 version to the latest
- Verifies that all 3 of these directories are identical

By adding more and more operations (done by implementing a simple interface) we can simulate random FS updates very quickly and ensure that DL always produces the correct results.

If an error is detected it will print the list of operations necessary to reproduce that error. One interesting feature many similar tools implement is the ability to try and prune the operation list necessary to create the fault. To do this it will randomly prune operations from the list trying to create the smallest possible failure case.

I called this `fuzz testing` but technically I think this is actually property testing or generative testing: https://en.wikipedia.org/wiki/Software_testing#Property_testing

Improvements:
- ~Add plenty of new operations (symlinks, pack files, deletes, ...)~ done
- ~Add a test where we build to a random version and then rebuild up to the latest version from there~ done
- ~Integrate with CI~ done