### PR TITLE
Close open queries when function early exits

### DIFF
--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -286,7 +286,8 @@ func (f *Fs) Get(req *pb.GetRequest, stream pb.Fs_GetServer) error {
 			key.QueryIgnores.Field(query.Ignores),
 		)
 
-		objects, err := db.GetObjects(ctx, tx, packManager, req.Project, vrange, query)
+		objects, closeFunc, err := db.GetObjects(ctx, tx, packManager, req.Project, vrange, query)
+		defer closeFunc(ctx)
 		if err != nil {
 			return status.Errorf(codes.Internal, "FS get objects: %v", err)
 		}
@@ -365,7 +366,8 @@ func (f *Fs) GetCompress(req *pb.GetCompressRequest, stream pb.Fs_GetCompressSer
 			key.QueryIgnores.Field(query.Ignores),
 		)
 
-		tars, err := db.GetTars(ctx, tx, req.Project, req.AvailableCacheVersions, vrange, query)
+		tars, closeFunc, err := db.GetTars(ctx, tx, req.Project, req.AvailableCacheVersions, vrange, query)
+		defer closeFunc(ctx)
 		if err != nil {
 			return status.Errorf(codes.Internal, "FS get tars: %v", err)
 		}
@@ -588,7 +590,8 @@ func (f *Fs) Inspect(ctx context.Context, req *pb.InspectRequest) (*pb.InspectRe
 		Path:     "",
 		IsPrefix: true,
 	}
-	objects, err := db.GetObjects(ctx, tx, packManager, req.Project, vrange, query)
+	objects, closeFunc, err := db.GetObjects(ctx, tx, packManager, req.Project, vrange, query)
+	defer closeFunc(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "FS get objects: %v", err)
 	}
@@ -868,7 +871,8 @@ func (f *Fs) GetCache(req *pb.GetCacheRequest, stream pb.Fs_GetCacheServer) erro
 
 	logger.Debug(ctx, "FS.GetCache[Init]")
 
-	tars, err := db.GetCacheTars(ctx, tx)
+	tars, closeFunc, err := db.GetCacheTars(ctx, tx)
+	defer closeFunc(ctx)
 	if err != nil {
 		return status.Errorf(codes.Internal, "FS get cached tars: %v", err)
 	}

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -156,7 +156,8 @@ func TestGetCacheWithMultipleVersions(t *testing.T) {
 		Path:     "pack",
 		IsPrefix: true,
 	}
-	tars, err := db.GetTars(tc.Context(), tc.Connect(), 1, availableVersions, vrange, query)
+	tars, closeFunc, err := db.GetTars(tc.Context(), tc.Connect(), 1, availableVersions, vrange, query)
+	defer closeFunc(tc.Context())
 	require.NoError(t, err)
 
 	var paths []string


### PR DESCRIPTION
This is a small fix for an issue we've been seeing in prod.

In a query that exceeds its deadline, we cancel the GRPC endpoint function early.

In that case we end up in the deferred `cancel` function - in which we rollback the transaction and return the query connection to the pool.

However, when we try and call `tx.Rollback(ctx)` we get an error that the connection is busy. This is because the `Rows` object that we returned within a closure, is still open.

So this adds an extra close function that allows us to ensure that the `Rows` object is closed before we tear down to transaction.