### PR TITLE
Add GC to JS client

### DIFF
--- a/js/spec/grpc-client.spec.ts
+++ b/js/spec/grpc-client.spec.ts
@@ -18,4 +18,23 @@ describe("grpc client operations", () => {
 
     expect(result?.content?.toString()).toBe("a v1");
   });
+
+  it("can GC updated objects", async () => {
+    await grpcClient.newProject(1337n, []);
+
+    for (let i = 0; i < 20; i++) {
+      const content = encodeContent(`a v${i}`);
+      await grpcClient.updateObject(1337n, {
+        path: "a",
+        mode: 0o755n,
+        content: content,
+        size: BigInt(content.length),
+        deleted: false,
+      });
+    }
+
+    const result = await grpcClient.gcProject(1337n, 5n, 2n);
+
+    expect(result).toBe(12n);
+  });
 });

--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -321,10 +321,10 @@ export class DateiLagerGrpcClient {
    * This method assumes that it is always a one way clone from source to target, it does not take into account
    * the changes that have occurred in the `target` project.
    *
-   * @param source      The source project.
-   * @param target      The target project.
-   * @param version     The version of the source project to clone up to.
-   * @returns           The new version number of the target project
+   * @param source  The source project.
+   * @param target  The target project.
+   * @param version The version of the source project to clone up to.
+   * @returns         The new version number of the target project.
    */
   public async cloneToProject(source: bigint, target: bigint, version: bigint): Promise<CloneToProjectResponse> {
     return await trace(
@@ -341,6 +341,53 @@ export class DateiLagerGrpcClient {
         return call.response;
       }
     );
+  }
+
+  /**
+   * GC project.
+   *
+   * @param project The project to GC.
+   * @param keep    The amount of versions since the latest that should be kept.
+   * @param from    The starting version to GC from.
+   * @returns         The amount of objects that were GC'd.
+   */
+  public async gcProject(project: bigint, keep: bigint, from?: bigint): Promise<bigint> {
+    const call = await this._client.gcProject({
+      project: project,
+      keepVersions: keep,
+      fromVersion: from,
+    });
+    return call.response.count;
+  }
+
+  /**
+   * GC random projects.
+   *
+   * @param sample The percentage of projects to sample from.
+   * @param keep   The amount of versions since the latest that should be kept.
+   * @param from   The starting version to GC from.
+   * @returns        The amount of objects that were GC'd.
+   */
+  public async gcRandomProjects(sample: number, keep: bigint, from?: bigint): Promise<bigint> {
+    const call = await this._client.gcRandomProjects({
+      sample: sample,
+      keepVersions: keep,
+      fromVersion: from,
+    });
+    return call.response.count;
+  }
+
+  /**
+   * GC contents.
+   *
+   * @param sample The percentage of projects to sample from.
+   * @returns        The amount of objects that were GC'd.
+   */
+  public async gcContents(sample: number): Promise<bigint> {
+    const call = await this._client.gcContents({
+      sample: sample,
+    });
+    return call.response.count;
   }
 }
 


### PR DESCRIPTION
Since we'll be calling this from a Temporal cron, it would be nice to make this available from the JS API.

These endpoints can still only be called if you have an Admin token.