### PR TITLE
Configure keepalive for client and server

### DIFF
--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -91,7 +91,12 @@ export class DateiLagerGrpcClient {
             .catch(callback);
         })
       ),
-      clientOptions: options.grpcClientOptions,
+      clientOptions: {
+        "grpc.keepalive_time_ms": 10_000,
+        "grpc.keepalive_timeout_ms": 5_000,
+        "grpc.keepalive_permit_without_calls": 1,
+        ...options.grpcClientOptions,
+      },
     });
 
     this._client = new FsClient(this._transport);

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
+	"google.golang.org/grpc/keepalive"
 )
 
 const (
@@ -99,6 +100,11 @@ func NewClient(ctx context.Context, server string, opts ...func(*options)) (*Cli
 			grpc.MaxCallRecvMsgSize(MAX_MESSAGE_SIZE),
 			grpc.MaxCallSendMsgSize(MAX_MESSAGE_SIZE),
 		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             5 * time.Second,
+			PermitWithoutStream: true,
+		}),
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -136,6 +137,14 @@ func NewServer(ctx context.Context, dbConn *DbPoolConnector, cert *tls.Certifica
 		grpc.MaxRecvMsgSize(MAX_MESSAGE_SIZE),
 		grpc.MaxSendMsgSize(MAX_MESSAGE_SIZE),
 		grpc.Creds(creds),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    10 * time.Second,
+			Timeout: 5 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	)
 
 	logger.Info(ctx, "register HealthServer")


### PR DESCRIPTION
We've noticed `4 DEADLINE_EXCEEDED` errors appearing after we deploy a new version of DL. We think it's because we're attempting to re-use a connection to a shutdown server.

Setting these keepalive defaults _should_ help our clients realize their connection isn't working anymore and reconnect to a new server quicker.