### PR TITLE
Change keepalive settings

### DIFF
--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -92,8 +92,8 @@ export class DateiLagerGrpcClient {
         })
       ),
       clientOptions: {
-        "grpc.keepalive_time_ms": 10_000,
-        "grpc.keepalive_timeout_ms": 5_000,
+        "grpc.keepalive_time_ms": 5_000,
+        "grpc.keepalive_timeout_ms": 1_000,
         "grpc.keepalive_permit_without_calls": 1,
         ...options.grpcClientOptions,
       },

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -109,8 +109,8 @@ func NewClient(ctx context.Context, server string, opts ...func(*options)) (*Cli
 			grpc.MaxCallSendMsgSize(MAX_MESSAGE_SIZE),
 		),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
-			Timeout:             5 * time.Second,
+			Time:                5 * time.Second,
+			Timeout:             1 * time.Second,
 			PermitWithoutStream: true,
 		}),
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -145,12 +145,8 @@ func NewServer(ctx context.Context, dbConn *DbPoolConnector, cert *tls.Certifica
 		grpc.MaxRecvMsgSize(MAX_MESSAGE_SIZE),
 		grpc.MaxSendMsgSize(MAX_MESSAGE_SIZE),
 		grpc.Creds(creds),
-		grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time:    10 * time.Second,
-			Timeout: 5 * time.Second,
-		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             10 * time.Second,
+			MinTime:             2 * time.Second,
 			PermitWithoutStream: true,
 		}),
 	)


### PR DESCRIPTION
We're seeing a lot of these logs after shipping #23

```
E Connection to dns:dateilager.gadget-services.net:5051 at 10.128.15.200:5051 rejected by server because of excess pings. Increasing ping interval to 20000 ms
```

This is weird because our clients were configured to send pings every 10 seconds and our servers were configured to allow client pings every 10 seconds. I _think_ the reason our server is rejecting pings is because of the latency between the client and the server.

1. Client sends ping at 00:00 and starts 10-second timer
2. Server receives ping at 00:01 and starts 10-second timer
3. Client sends ping at 00:10
4. Server rejects Client ping because it's before 00:11

---

We've also noticed that our `DEADLINE exceeded` errors haven't gone away which was the original point of #23

To help solve both of these issues I've changed our keep alive settings to the following:

1. Change client ping interval from `10` -> `5` seconds and ping timeout from `5` -> `1` second. This will reduce our "connection might be dead" window from `15` -> `6` seconds and hopefully help our `DEADLINE exceeded` issues.
2. Change server to allow client ping interval from `10` -> `2` seconds. This allows our clients to ping every `5` seconds with `3` seconds of room for latency.
3. Change server ping interval from `10` seconds -> `2` hours (default). This keeps our amount of overall pings the same and I don't think we get much value from our servers pinging clients.

---

I've 🎩  these settings locally for about ~30 mins and haven't seen any `rejected by server because of excess pings` logs.