### PR TITLE
Use fallocate

### DIFF
--- a/internal/files/preallocate.go
+++ b/internal/files/preallocate.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package files
+
+import (
+	"os"
+)
+
+func PreAllocate(file *os.File, size int64) error {
+	return nil
+}

--- a/internal/files/preallocate_linux.go
+++ b/internal/files/preallocate_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package files
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func PreAllocate(file *os.File, size int64) error {
+	if size > 0 {
+		return unix.Fallocate(int(file.Fd()), 0, 0, size)
+	}
+	return nil
+}

--- a/internal/files/writer.go
+++ b/internal/files/writer.go
@@ -62,6 +62,10 @@ func writeObject(rootDir string, cacheObjectsDir string, reader *db.TarReader, h
 			return fmt.Errorf("open file %v: %w", path, err)
 		}
 
+		err = PreAllocate(file, header.Size)
+		if err != nil {
+			return fmt.Errorf("failed to pre allocate %v: %w", path, err)
+		}
 		err = reader.CopyContent(file)
 		file.Close()
 		if err != nil {


### PR DESCRIPTION
A cool little trick I saw mentioned somewhere else.

There's a Linux only syscall that lets you tell the kernel how big a file is going to be and has it pre-allocate the necessary blocks.

This is mainly used for writing really large files by ensuring they can be written before starting the write.

However, it also happens to speed up write performance as it is not allocating blocks multiple times for a single file write.

When benchmarking the `WriteTar` function this provides a 9% improvement on my machine.