### PR TITLE
Support ignores for the rebuild command

### DIFF
--- a/cmd/fuzz-test/main.go
+++ b/cmd/fuzz-test/main.go
@@ -415,12 +415,12 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 		return -1, fmt.Errorf("failed to create reset dir %s: %w", dirs.Reset(project), err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), "")
+	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild reset project %d: %w", project, err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), "")
+	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild continue project %d: %w", project, err)
 	}
@@ -432,11 +432,11 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 	}
 
 	randomStepVersion := int64(rand.Intn(int(version)))
-	_, _, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), "")
+	_, _, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}
-	_, _, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), "")
+	_, _, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}

--- a/js/src/binary-client.ts
+++ b/js/src/binary-client.ts
@@ -155,9 +155,15 @@ export class DateiLagerBinaryClient {
    * @param directory       The path of the directory to rebuild the filesystem at.
    * @param options         Object of options.
    * @param options.timeout Number of milliseconds to wait before terminating the process.
+   * @param options.ignores The paths to ignore when rebuilding the FS.
    * @returns                 The latest project version or `null` if something went wrong.
    */
-  public async rebuild(project: bigint, to: bigint | null, directory: string, options?: { timeout: number }): Promise<bigint | null> {
+  public async rebuild(
+    project: bigint,
+    to: bigint | null,
+    directory: string,
+    options?: { timeout: number; ignores: string[] }
+  ): Promise<bigint | null> {
     return await trace(
       "dateilager-binary-client.rebuild",
       {
@@ -173,6 +179,10 @@ export class DateiLagerBinaryClient {
         const args = ["--dir", directory];
         if (to) {
           args.push("--to", String(to));
+        }
+
+        if (options?.ignores) {
+          args.push("--ignores", options.ignores.join(","));
         }
 
         const result = await this._call("rebuild", project, directory, args, options);

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gadget-inc/dateilager/internal/key"
 	"github.com/gadget-inc/dateilager/internal/logger"
@@ -15,6 +16,7 @@ func NewCmdRebuild() *cobra.Command {
 		to      *int64
 		prefix  string
 		dir     string
+		ignores string
 	)
 
 	cmd := &cobra.Command{
@@ -25,10 +27,14 @@ func NewCmdRebuild() *cobra.Command {
 			}
 
 			ctx := cmd.Context()
-
 			client := client.FromContext(ctx)
 
-			version, count, err := client.Rebuild(ctx, project, prefix, to, dir, "")
+			var ignoreList []string
+			if len(ignores) > 0 {
+				ignoreList = strings.Split(ignores, ",")
+			}
+
+			version, count, err := client.Rebuild(ctx, project, prefix, to, dir, ignoreList, "")
 			if err != nil {
 				return fmt.Errorf("could not rebuild project: %w", err)
 			}
@@ -56,6 +62,7 @@ func NewCmdRebuild() *cobra.Command {
 	cmd.Flags().Int64Var(&project, "project", -1, "Project ID (required)")
 	cmd.Flags().StringVar(&prefix, "prefix", "", "Search prefix")
 	cmd.Flags().StringVar(&dir, "dir", "", "Output directory")
+	cmd.Flags().StringVar(&ignores, "ignores", "", "Comma separated list of ignore paths")
 	to = cmd.Flags().Int64("to", -1, "To version ID (optional)")
 
 	_ = cmd.MarkFlagRequired("project")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -232,7 +232,7 @@ func (c *Client) Get(ctx context.Context, project int64, prefix string, ignores 
 	return objects, nil
 }
 
-func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVersion *int64, dir string, cacheDir string) (int64, uint32, error) {
+func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVersion *int64, dir string, ignores []string, cacheDir string) (int64, uint32, error) {
 	ctx, span := telemetry.Start(ctx, "client.rebuild", trace.WithAttributes(
 		key.Project.Attribute(project),
 		key.Prefix.Attribute(prefix),
@@ -256,6 +256,7 @@ func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVe
 	query := &pb.ObjectQuery{
 		Path:     prefix,
 		IsPrefix: true,
+		Ignores:  ignores,
 	}
 
 	availableCacheVersions := ReadCacheVersionFile(cacheDir)
@@ -498,7 +499,7 @@ func (c *Client) Update(rootCtx context.Context, project int64, dir string) (int
 			return -1, updateCount, err
 		}
 	} else {
-		toVersion, _, err = c.Rebuild(rootCtx, project, "", nil, dir, "")
+		toVersion, _, err = c.Rebuild(rootCtx, project, "", nil, dir, nil, "")
 		if err != nil {
 			return -1, updateCount, err
 		}

--- a/test/shared_test.go
+++ b/test/shared_test.go
@@ -393,7 +393,7 @@ func rebuild(tc util.TestCtx, c *client.Client, project int64, toVersion *int64,
 		cacheDir = &newCacheDir
 	}
 
-	version, count, err := c.Rebuild(tc.Context(), project, "", toVersion, dir, *cacheDir)
+	version, count, err := c.Rebuild(tc.Context(), project, "", toVersion, dir, nil, *cacheDir)
 	require.NoError(tc.T(), err, "client.Rebuild")
 
 	assert.Equal(tc.T(), expected.version, version, "mismatch rebuild version")


### PR DESCRIPTION
Add support for `--ignores` when rebuilding.

This will be useful to not pull down typedocs for our projects.