### PR TITLE
Share the TAR reader

### DIFF
--- a/internal/db/query.go
+++ b/internal/db/query.go
@@ -81,7 +81,8 @@ func NewVersionRange(ctx context.Context, tx pgx.Tx, project int64, from *int64,
 
 func unpackObjects(content []byte) ([]*pb.Object, error) {
 	var objects []*pb.Object
-	tarReader := NewTarReader(content)
+	tarReader := NewTarReader()
+	tarReader.FromBytes(content)
 
 	for {
 		header, err := tarReader.Next()

--- a/internal/db/tar.go
+++ b/internal/db/tar.go
@@ -141,13 +141,19 @@ type TarReader struct {
 	tarReader *tar.Reader
 }
 
-func NewTarReader(content []byte) *TarReader {
-	s2Reader := s2.NewReader(bytes.NewBuffer(content))
+func NewTarReader() *TarReader {
+	var buffer bytes.Buffer
+	s2Reader := s2.NewReader(&buffer)
 
 	return &TarReader{
 		s2Reader:  s2Reader,
 		tarReader: tar.NewReader(s2Reader),
 	}
+}
+
+func (t *TarReader) FromBytes(content []byte) {
+	t.s2Reader.Reset(bytes.NewBuffer(content))
+	t.tarReader = tar.NewReader(t.s2Reader)
 }
 
 func (t *TarReader) Next() (*tar.Header, error) {
@@ -210,7 +216,8 @@ func updateObjects(before []byte, updates []*pb.Object) ([]byte, error) {
 	seenPaths := make(map[string]bool)
 	idxHint := 0
 
-	reader := NewTarReader(before)
+	reader := NewTarReader()
+	reader.FromBytes(before)
 	readerObjectsRemaining := true
 
 	sort.Slice(updates, func(i, j int) bool { return updates[i].Path < updates[j].Path })

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -169,7 +169,8 @@ func TestGetCacheWithMultipleVersions(t *testing.T) {
 		if err == db.SKIP {
 			continue
 		}
-		tarReader := db.NewTarReader(tar)
+		tarReader := db.NewTarReader()
+		tarReader.FromBytes(tar)
 
 		for {
 			header, err := tarReader.Next()


### PR DESCRIPTION
The `s2.Reader` allocates memory under the hood and it is quicker to share it then to create new ones on every iteration.