### PR TITLE
Report all changes in calls to rebuild and update

### DIFF
--- a/cmd/fuzz-test/main.go
+++ b/cmd/fuzz-test/main.go
@@ -415,12 +415,12 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 		return -1, fmt.Errorf("failed to create reset dir %s: %w", dirs.Reset(project), err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), nil, "", false)
+	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild reset project %d: %w", project, err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), nil, "", false)
+	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild continue project %d: %w", project, err)
 	}
@@ -431,11 +431,11 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 	}
 
 	randomStepVersion := int64(rand.Intn(int(version)))
-	_, _, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), nil, "", false)
+	_, _, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}
-	_, _, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), nil, "", false)
+	_, _, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), nil, "")
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   version = "0.4.6";
   src = ./.;
   proxyVendor = true; # Fixes: cannot query module due to -mod=vendor running make install
-  vendorSha256 = "sha256-h5FEdWFBr2IUP9A/XeZ7KPFNmSdUVa6+3YEZXfYTJyU=";
+  vendorSha256 = "sha256-alWynGHIxSH3GcMiqgO10u3lRcZ2AmWrU5NTN4UcEl4=";
 
   outputs = [ "out" "client" "server" "webui" "assets" "migrations" ];
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gadget-inc/dateilager
 go 1.18
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/gadget-inc/fsdiff v0.4.4
 	github.com/go-chi/chi/v5 v5.0.7
@@ -23,6 +24,7 @@ require (
 	go.uber.org/zap v1.23.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
+	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43
 	google.golang.org/grpc v1.50.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -59,7 +61,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
-	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 // indirect
 	golang.org/x/text v0.3.8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221014173430-6e2ab493f96b // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635/go.mod h1:lmLxL+FV29
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -3,12 +3,17 @@ import { encodeContent } from "../src";
 import { binaryClient, grpcClient, tmpdir } from "./util";
 
 describe("binary client operations", () => {
-  it("can rebuild the file system", async () => {
-    const project = 1337n;
-    const path = "hello.txt";
-    const content = "hello world";
+  const project = 1337n;
+  const path = "hello.txt";
+  let dir: string;
 
+  beforeEach(async () => {
+    dir = tmpdir();
     await grpcClient.newProject(project, []);
+  });
+
+  it("can rebuild the file system", async () => {
+    const content = "hello world";
     const encodedContent = encodeContent(content);
 
     await grpcClient.updateObject(project, {
@@ -19,7 +24,6 @@ describe("binary client operations", () => {
       deleted: false,
     });
 
-    const dir = tmpdir();
     await binaryClient.rebuild(project, null, dir);
 
     const filepath = `${dir}/${path}`;
@@ -28,4 +32,92 @@ describe("binary client operations", () => {
     const fileContent = fs.readFileSync(filepath).toString();
     expect(fileContent).toBe(content);
   });
+
+  it("can update the file system", async () => {
+    await binaryClient.rebuild(project, null, dir);
+
+    const filepath = `${dir}/${path}`;
+    fs.writeFileSync(filepath, "hello world", { encoding: "utf8" });
+
+    const result = await binaryClient.update(project, dir);
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(1n);
+    expect(result!.updates).toBeFalsy()
+  });
+
+  it("can update the file system and return updates in a list", async () => {
+    await binaryClient.rebuild(project, null, dir);
+
+    fs.writeFileSync(`${dir}/a`, "a content", { encoding: "utf8" });
+    fs.writeFileSync(`${dir}/b`, "b content", { encoding: "utf8" });
+
+    const result = await binaryClient.update(project, dir, { listUpdated: true });
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(1n);
+    expect(sortUpdates(result!.updates!)).toEqual(sortUpdates([
+      {
+        operation: "ADD",
+        path: "a",
+      },
+      {
+        operation: "ADD",
+        path: "b",
+      },
+    ]));
+  });
+
+  it("can update the file system and log updates when a directory turns into a file", async () => {
+    await binaryClient.rebuild(project, null, dir);
+
+    fs.mkdirSync(`${dir}/a`);
+
+    let result = await binaryClient.update(project, dir, { listUpdated: true });
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(1n);
+    expect(result!.updates!.sort()).toEqual([
+      {
+        operation: "ADD",
+        path: "a/",
+      },
+    ]);
+
+    fs.rmdirSync(`${dir}/a`);
+    fs.writeFileSync(`${dir}/a`, "a content", { encoding: "utf8" });
+
+    result = await binaryClient.update(project, dir, { listUpdated: true });
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(2n);
+    expect(sortUpdates(result!.updates!)).toEqual(sortUpdates([
+      {
+        operation: "REMOVE",
+        path: "a/",
+      },
+      {
+        operation: "ADD",
+        path: "a",
+      },
+    ]));
+  });
+
+  it("updates where nothing change return a result", async () => {
+    await binaryClient.rebuild(project, null, dir);
+    const result = await binaryClient.update(project, dir, { listUpdated: true });
+    expect(result).toBeTruthy();
+    expect(result!.version).toEqual(0n);
+    expect(result!.updates!).toEqual([]);
+  });
 });
+
+const sortUpdates = (updates: any[]) => {
+  return updates.sort((a, b) => {
+    const aString = JSON.stringify(a);
+    const bString = JSON.stringify(b);
+    if (aString < bString) {
+      return -1;
+    }
+    if (aString > bString) {
+      return 1;
+    }
+    return 0;
+  })
+}

--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -3,19 +3,22 @@ import { encodeContent } from "../src";
 import { binaryClient, grpcClient, tmpdir } from "./util";
 
 describe("binary client operations", () => {
-  const project = 1337n;
   const path = "hello.txt";
   let dir: string;
+  const content = "hello world";
+  const encodedContent = encodeContent(content);
+
+  let project: bigint;
+  let counter = 1;
 
   beforeEach(async () => {
     dir = tmpdir();
+    counter += 1;
+    project = BigInt(counter);
     await grpcClient.newProject(project, []);
   });
 
   it("can rebuild the file system", async () => {
-    const content = "hello world";
-    const encodedContent = encodeContent(content);
-
     await grpcClient.updateObject(project, {
       path,
       mode: 0o755n,
@@ -24,13 +27,63 @@ describe("binary client operations", () => {
       deleted: false,
     });
 
-    await binaryClient.rebuild(project, null, dir);
+    const result = await binaryClient.rebuild(project, null, dir);
+    expect(result.version).toBeDefined();
+    expect(result.updates).toBeUndefined();
+    expect(result.globsMatched).toBeUndefined();
 
     const filepath = `${dir}/${path}`;
     expect(fs.existsSync(filepath)).toBe(true);
 
     const fileContent = fs.readFileSync(filepath).toString();
     expect(fileContent).toBe(content);
+  });
+
+  it("can rebuild the file system and list changed files", async () => {
+    await grpcClient.updateObject(project, {
+      path,
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    const result = await binaryClient.rebuild(project, null, dir, { listUpdated: true });
+    expect(result.version).toBeDefined();
+    expect(result.updates).toEqual([
+      {
+        operation: "ADD",
+        path: "hello.txt",
+      },
+    ]);
+  });
+
+  it("can rebuild the file system and check changed files against a list of globs", async () => {
+    await grpcClient.updateObject(project, {
+      path,
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    const result = await binaryClient.rebuild(project, null, dir, { checkGlobs: ["hello.*", "goodbye.*"] });
+    expect(result.version).toBeDefined();
+    expect(result.globsMatched).toEqual(true);
+  });
+
+  it("can rebuild the file system and check changed files against a list of globs where none match", async () => {
+    await grpcClient.updateObject(project, {
+      path,
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    const result = await binaryClient.rebuild(project, null, dir, { checkGlobs: ["foo/**/bar", "baz"] });
+    expect(result.version).toBeDefined();
+    expect(result.globsMatched).toEqual(false);
   });
 
   it("can update the file system", async () => {
@@ -42,7 +95,7 @@ describe("binary client operations", () => {
     const result = await binaryClient.update(project, dir);
     expect(result).toBeTruthy();
     expect(result!.version).toBe(1n);
-    expect(result!.updates).toBeFalsy()
+    expect(result!.updates).toBeFalsy();
   });
 
   it("can update the file system and return updates in a list", async () => {
@@ -54,16 +107,30 @@ describe("binary client operations", () => {
     const result = await binaryClient.update(project, dir, { listUpdated: true });
     expect(result).toBeTruthy();
     expect(result!.version).toBe(1n);
-    expect(sortUpdates(result!.updates!)).toEqual(sortUpdates([
-      {
-        operation: "ADD",
-        path: "a",
-      },
-      {
-        operation: "ADD",
-        path: "b",
-      },
-    ]));
+    expect(sortUpdates(result!.updates!)).toEqual(
+      sortUpdates([
+        {
+          operation: "ADD",
+          path: "a",
+        },
+        {
+          operation: "ADD",
+          path: "b",
+        },
+      ])
+    );
+  });
+
+  it("can update the file system checking file globs for matches", async () => {
+    await binaryClient.rebuild(project, null, dir);
+
+    fs.writeFileSync(`${dir}/a`, "a content", { encoding: "utf8" });
+    fs.writeFileSync(`${dir}/b`, "b content", { encoding: "utf8" });
+
+    const result = await binaryClient.update(project, dir, { checkGlobs: ["a"] });
+    expect(result).toBeTruthy();
+    expect(result!.version).toBe(1n);
+    expect(result!.globsMatched).toBeTruthy();
   });
 
   it("can update the file system and log updates when a directory turns into a file", async () => {
@@ -87,16 +154,18 @@ describe("binary client operations", () => {
     result = await binaryClient.update(project, dir, { listUpdated: true });
     expect(result).toBeTruthy();
     expect(result!.version).toBe(2n);
-    expect(sortUpdates(result!.updates!)).toEqual(sortUpdates([
-      {
-        operation: "REMOVE",
-        path: "a/",
-      },
-      {
-        operation: "ADD",
-        path: "a",
-      },
-    ]));
+    expect(sortUpdates(result!.updates!)).toEqual(
+      sortUpdates([
+        {
+          operation: "REMOVE",
+          path: "a/",
+        },
+        {
+          operation: "ADD",
+          path: "a",
+        },
+      ])
+    );
   });
 
   it("updates where nothing change return a result", async () => {
@@ -108,7 +177,7 @@ describe("binary client operations", () => {
   });
 });
 
-const sortUpdates = (updates: any[]) => {
+const sortUpdates = (updates: { path: string; operation: string }[]) => {
   return updates.sort((a, b) => {
     const aString = JSON.stringify(a);
     const bString = JSON.stringify(b);
@@ -119,5 +188,5 @@ const sortUpdates = (updates: any[]) => {
       return 1;
     }
     return 0;
-  })
-}
+  });
+};

--- a/test/client_combined_test.go
+++ b/test/client_combined_test.go
@@ -194,7 +194,7 @@ func TestCombinedWithChangingObjectTypes(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   3,
+		count:   5,
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{
@@ -235,7 +235,7 @@ func TestCombinedNonEmptyDirectoryIntoFile(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   1,
+		count:   2,
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{
@@ -275,7 +275,7 @@ func TestCombinedNonEmptyDirectoryIntoSymlink(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   2,
+		count:   3,
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{
@@ -315,7 +315,7 @@ func TestCombinedFileIntoNonEmptyDirectory(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   1,
+		count:   2,
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{
@@ -354,7 +354,7 @@ func TestCombinedFileIntoEmptyDirectory(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   1,
+		count:   2,
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{
@@ -405,7 +405,7 @@ func TestCombinedWithPacked(t *testing.T) {
 
 	rebuild(tc, c, 1, i(2), tmpDir, nil, expectedResponse{
 		version: 2,
-		count:   3, // We updated a pack so all of them were rebuilt
+		count:   4, // We updated a pack so all of them were rebuilt
 	})
 
 	verifyDir(t, tmpDir, 2, map[string]expectedFile{


### PR DESCRIPTION
Before this change, callers of the binary client know how many things changed, but not which things changed. There's a few bits of business logic gadget side that would be a lot easier if they knew exactly what changed, namely looking for changes to package.json during operation-runner commands, or looking for changes only to client-side files so we don't need to restart the server. This hands that information back to the client so they can work with it. We were already generating it so no huge performance hit there, but it will potentially be big when we send it back to the client so I think we may need to use this carefully.