### PR TITLE
Add the ability to detect file patterns while rebuilding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,12 +6,11 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   enable:
     - depguard
-    - dogsled
+
     - errcheck
     - exportloopref
     - goconst
     - gocritic
-    - gocyclo
     - gofmt
     - goimports
     - goprintffuncname
@@ -25,13 +24,11 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
-
-  # linters disabled because of go1.18 (see https://github.com/golangci/golangci-lint/issues/2649):
-  # - bodyclose
-  # - noctx
-  # - structcheck
+    - bodyclose
+    - noctx
+    - dogsled
+    - gocyclo
 
   # don't enable:
   # - wsl
@@ -41,5 +38,5 @@ linters:
 # Options for analysis running.
 run:
   skip-files:
-  - "internal/pb/*.pb.go$"
-  - internal/pb/object.go
+    - "internal/pb/*.pb.go$"
+    - internal/pb/object.go

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PROTO_FILES := $(shell find internal/pb/ -type f -name '*.proto')
 MIGRATE_DIR := ./migrations
 SERVICE := $(PROJECT).server
 
-.PHONY: install migrate migrate-create clean build release
+.PHONY: install migrate migrate-create clean build lint release
 .PHONY: test test-one test-fuzz test-js lint-js build-js
 .PHONY: reset-db setup-local server server-profile install-js
 .PHONY: client-update client-large-update client-get client-rebuild client-pack
@@ -73,6 +73,9 @@ development/server.key:
 development/server.crt: development/server.key
 
 build: internal/pb/fs.pb.go internal/pb/fs_grpc.pb.go bin/server bin/client bin/webui  development/server.crt
+
+lint:
+	golangci-lint run
 
 release/%_linux_amd64: cmd/%/main.go $(PKG_GO_FILES) $(INTERNAL_GO_FILES) go.sum
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(BUILD_FLAGS) -o $@ $<

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ You can read more about DateiLager's design in the `docs/` directory. A good pla
 
 ### Requirements
 
-- Go 1.18
+- Go 1.19
 - Postgresql
 - Node v16
 - mkcert (https://github.com/FiloSottile/mkcert)
@@ -33,7 +33,7 @@ $ export DB_HOST=10.0.0.1
 
 ### Install Toolchains
 
-Ensure that you have a working [Go development environment](https://golang.org/doc/install) and that you are running at least Go 1.18.
+Ensure that you have a working [Go development environment](https://golang.org/doc/install) and that you are running at least Go 1.19.
 
 You will also require `npm`.
 

--- a/cmd/fuzz-test/main.go
+++ b/cmd/fuzz-test/main.go
@@ -415,12 +415,12 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 		return -1, fmt.Errorf("failed to create reset dir %s: %w", dirs.Reset(project), err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), nil, "", false)
+	_, err = client.Rebuild(ctx, project, "", nil, dirs.Reset(project), nil, "", nil, false)
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild reset project %d: %w", project, err)
 	}
 
-	_, _, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), nil, "", false)
+	_, err = client.Rebuild(ctx, project, "", nil, dirs.OneStep(project), nil, "", nil, false)
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild continue project %d: %w", project, err)
 	}
@@ -431,11 +431,11 @@ func runIteration(ctx context.Context, client *dlc.Client, project int64, operat
 	}
 
 	randomStepVersion := int64(rand.Intn(int(version)))
-	_, _, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), nil, "", false)
+	_, err = client.Rebuild(ctx, project, "", &randomStepVersion, dirs.RandomStep(project), nil, "", nil, false)
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}
-	_, _, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), nil, "", false)
+	_, err = client.Rebuild(ctx, project, "", &version, dirs.RandomStep(project), nil, "", nil, false)
 	if err != nil {
 		return -1, fmt.Errorf("failed to rebuild step project %d: %w", project, err)
 	}

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   version = "0.4.6";
   src = ./.;
   proxyVendor = true; # Fixes: cannot query module due to -mod=vendor running make install
-  vendorSha256 = "sha256-h5FEdWFBr2IUP9A/XeZ7KPFNmSdUVa6+3YEZXfYTJyU=";
+  vendorSha256 = "sha256-CZmCLHfNKXA2BLFbd4V78IrAsMnWN79MGLOvquu+AG0=";
 
   outputs = [ "out" "client" "server" "webui" "assets" "migrations" ];
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654007547,
-        "narHash": "sha256-G812EeXZeGeGjkAvbTleGwcKFCGxdLOQb9aViOWASPc=",
+        "lastModified": 1676150441,
+        "narHash": "sha256-Nfeua9Ua/dGHOQpzOjLtkyMyW/ysQCvZJ9Dd74QQSNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5643714dea562f0161529ab23058562afeff46d0",
+        "rev": "6d87734c880d704f6ee13e5c0fe835b98918c34e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
 
             ## Pinned packages from nixpkgs
 
-            go = pkgs.go_1_18;
+            go = pkgs.go_1_19;
 
             nodejs = pkgs.nodejs-16_x;
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/gadget-inc/dateilager
 
-go 1.18
+go 1.19
 
 require (
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/gadget-inc/fsdiff v0.4.4
 	github.com/go-chi/chi/v5 v5.0.7
+	github.com/gobwas/glob v0.2.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jackc/pgx/v5 v5.0.2
 	github.com/jackc/puddle/v2 v2.0.0
@@ -23,6 +24,7 @@ require (
 	go.uber.org/zap v1.23.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
+	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43
 	google.golang.org/grpc v1.50.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -59,7 +61,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
-	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 // indirect
 	golang.org/x/text v0.3.8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221014173430-6e2ab493f96b // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -20,9 +20,74 @@ describe("binary client operations", () => {
     });
 
     const dir = tmpdir();
-    await binaryClient.rebuild(project, null, dir);
+    const result = await binaryClient.rebuild(project, null, dir);
+    expect(result?.version).toBe(1n);
 
     const filepath = `${dir}/${path}`;
+    expect(fs.existsSync(filepath)).toBe(true);
+
+    const fileContent = fs.readFileSync(filepath).toString();
+    expect(fileContent).toBe(content);
+  });
+
+  it("can rebuild the file system with a file pattern", async () => {
+    const project = 1337n;
+    const path = "hello.txt";
+    const content = "hello world";
+
+    await grpcClient.newProject(project, []);
+    const encodedContent = encodeContent(content);
+
+    await grpcClient.updateObject(project, {
+      path,
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    const dir = tmpdir();
+    const result = await binaryClient.rebuild(project, null, dir, { filePattern: "hello*" });
+    expect(result?.version).toBe(1n);
+    expect(result?.patternMatch).toBe(true);
+
+    const filepath = `${dir}/${path}`;
+    expect(fs.existsSync(filepath)).toBe(true);
+
+    const fileContent = fs.readFileSync(filepath).toString();
+    expect(fileContent).toBe(content);
+  });
+
+  it("can rebuild the file system with an iff file pattern", async () => {
+    const project = 1337n;
+    const path = "hello.txt";
+    const content = "hello world";
+
+    await grpcClient.newProject(project, []);
+    const encodedContent = encodeContent(content);
+
+    await grpcClient.updateObject(project, {
+      path,
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    await grpcClient.updateObject(project, {
+      path: "bar.txt",
+      mode: 0o755n,
+      content: encodedContent,
+      size: BigInt(encodedContent.length),
+      deleted: false,
+    });
+
+    const dir = tmpdir();
+    const result = await binaryClient.rebuild(project, null, dir, { filePattern: "hello*", filePatternIff: true });
+    expect(result?.version).toBe(2n);
+    expect(result?.patternMatch).toBe(false);
+
+    const filepath = `${dir}/bar.txt`;
     expect(fs.existsSync(filepath)).toBe(true);
 
     const fileContent = fs.readFileSync(filepath).toString();


### PR DESCRIPTION
This adds file pattern matching to rebuild.

This will be used to detect if (and sometimes if and only if) certain files change, such as front end files.

We can do this without re-summarizing the files on disk by watching the files being untarred.