### PR TITLE
feat(gc): handle invalid mode type

### DIFF
--- a/pkg/cli/gc.go
+++ b/pkg/cli/gc.go
@@ -67,8 +67,9 @@ func NewCmdGc() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("could not gc project %v: %w", project, err)
 				}
+			default:
+				return fmt.Errorf("Invalid mode type: %s", mode)
 			}
-
 			logger.Info(ctx, "cleaned contents", key.Count.Field(count))
 			return nil
 		},


### PR DESCRIPTION
For the GC if the input coming in contains `--mode <some_value` and the entry is not valid (not one of [contents, project, random-projects]) then it gets defaulted to contents which might lead to confusion if this was not intended