### PR TITLE
feat: gc is available in the binary-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ js/src/pb: $(PROTO_FILES)
 js/dist: js/node_modules js/src/pb
 	cd js && npm run build
 
-test-js: js/node_modules js/src/pb
+test-js: js/node_modules js/src/pb build migrate
 	cd js && npm run test
 
 lint-js: js/node_modules js/src/pb

--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -93,4 +93,25 @@ describe("binary client operations", () => {
     const fileContent = fs.readFileSync(filepath).toString();
     expect(fileContent).toBe(content);
   });
+
+  it("can gc random-projects and return the count cleaned up", async () => {
+    const result = await binaryClient.gcRandomProjects(90, 2n, -1n, { timeout: 90 });
+
+    expect(JSON.stringify(result)).toMatch('{"count":0}');
+    expect(result.count).toStrictEqual(0);
+  });
+
+  it("can gc a specific project and return the count cleaned up", async () => {
+    const result = await binaryClient.gcProject(1n, 2n, -1n, { timeout: 90 });
+
+    expect(JSON.stringify(result)).toMatch('{"count":0}');
+    expect(result.count).toStrictEqual(0);
+  });
+
+  it("can gc contents and successfully return the count of contents cleaned up", async () => {
+    const result = await binaryClient.gcContents(90, { timeout: 90 });
+
+    expect(JSON.stringify(result)).toMatch('{"count":1}');
+    expect(result.count).toStrictEqual(1);
+  });
 });

--- a/pkg/cli/gc.go
+++ b/pkg/cli/gc.go
@@ -1,13 +1,16 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"github.com/gadget-inc/dateilager/internal/key"
-	"github.com/gadget-inc/dateilager/internal/logger"
 	"github.com/gadget-inc/dateilager/pkg/client"
 	"github.com/spf13/cobra"
 )
+
+type GcResult struct {
+	Count int64 `json:"count"`
+}
 
 func NewCmdGc() *cobra.Command {
 	var (
@@ -70,16 +73,23 @@ func NewCmdGc() *cobra.Command {
 			default:
 				return fmt.Errorf("Invalid mode type: %s", mode)
 			}
-			logger.Info(ctx, "cleaned contents", key.Count.Field(count))
+
+			encoded, err := json.Marshal(GcResult{count})
+			if err != nil {
+				return fmt.Errorf("could not marshal result: %w", err)
+			}
+
+			fmt.Println(string(encoded))
+
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&mode, "mode", "contents", "GC Mode (contents | project | random-projects)")
-	cmd.Flags().Int64Var(&project, "project", -1, "Project ID (used by contents mode)")
-	cmd.Flags().Int64Var(&keep, "keep", -1, "Amount of versions to keep (used by project and random-project mode)")
-	from = cmd.Flags().Int64("from", -1, "Delete as of this version (used by project and random-project mode)")
-	cmd.Flags().Float32Var(&sample, "sample", -1, "Percent of rows to sample (used by contents and random-project mode)")
+	cmd.Flags().Int64Var(&project, "project", -1, "Project ID (used by project mode)")
+	cmd.Flags().Int64Var(&keep, "keep", -1, "Amount of versions to keep (used by project and random-projects mode)")
+	from = cmd.Flags().Int64("from", -1, "Delete as of this version (used by project and random-projects mode)")
+	cmd.Flags().Float32Var(&sample, "sample", -1, "Percent of rows to sample (used by contents and random-projects mode)")
 
 	_ = cmd.MarkFlagRequired("mode")
 


### PR DESCRIPTION
### Objective:
The garbage collector is set in place in order to be utilized to regularly cleanup the contents and objects table of the dateilager db. With many changes incoming from many different apps and dateilager managing all of those changes as versions as well as storing the data with each change (with respect to a debounce) one can quickly see how the database can and will grow incredibly large with many of the versions being stored with an improbability of ever being used again - (we can deem it defunct)

As such this PR invokes the garbage collector(already implemented) as a binary/npm package to be utilized for this regularly scheduled cleanup.

### High-Level Explanation:
Garbage collector gets called with a mode ('random-projects' | 'contents' | 'project') to periodically go in and cleanup unused versions with respect to the parameters


### Tests Written:
GC on mode: "contents"
GC on mode: "random-projects"
GC on mode: "project"



===============================
When time permits, requesting review from @angelini & @scott-rc 

GGT-3510