### PR TITLE
fix/chore(GC): add tracing to GCRandomProjects & handle temporal encoding/decoding

### DIFF
--- a/internal/db/gc.go
+++ b/internal/db/gc.go
@@ -4,10 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/telemetry"
 	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func GcProjectObjects(ctx context.Context, tx pgx.Tx, project int64, keep int64, fromVersion int64) ([]Hash, error) {
+	ctx, span := telemetry.Start(ctx, "gc.project-objects", trace.WithAttributes(
+		key.Project.Attribute(project),
+		key.KeepVersions.Attribute(keep),
+		key.FromVersion.Attribute(&fromVersion),
+	))
+	defer span.End()
+
 	hashes := []Hash{}
 
 	rows, err := tx.Query(ctx, `

--- a/js/src/binary-client.ts
+++ b/js/src/binary-client.ts
@@ -118,7 +118,7 @@ export interface GCResult {
   /**
    * The number of records garbage collected
    */
-  count: bigint;
+  count: number;
 }
 
 /**
@@ -270,7 +270,7 @@ export class DateiLagerBinaryClient {
         if (from) args.push("--from", String(from));
 
         const result = await this._call("gc", args, undefined, options);
-        const parsed = JSON.parse(result.stdout) as { count: bigint };
+        const parsed = JSON.parse(result.stdout) as { count: number };
         return { count: parsed.count };
       }
     );
@@ -300,7 +300,7 @@ export class DateiLagerBinaryClient {
         if (from) args.push("--from", String(from));
 
         const result = await this._call("gc", args, undefined, options);
-        const parsed = JSON.parse(result.stdout) as { count: bigint };
+        const parsed = JSON.parse(result.stdout) as { count: number };
         return { count: parsed.count };
       }
     );
@@ -325,7 +325,7 @@ export class DateiLagerBinaryClient {
         const args = ["--mode", "contents", "--sample", String(sample)];
 
         const result = await this._call("gc", args, undefined, options);
-        const parsed = JSON.parse(result.stdout) as { count: bigint };
+        const parsed = JSON.parse(result.stdout) as { count: number };
         return { count: parsed.count };
       }
     );


### PR DESCRIPTION
This PR change the GCResult to return count as a number rather than a bigint workflow to decode/encode properly.
Secondly this pr adds tracing for GCRandomProjects so we can keep track of which project IDS were chosen from the sample pool to be GC'ed

**GCResult now returns count as a number type instead of bigint**
Why `number`? Will it work? Good question.
The temporal docs specifically state: `To send values that are not [JSON-serializable](https://en.wikipedia.org/wiki/JSON#Data_types) like BigInts or Dates, provide a custom Data Converter to the Client and Worker:`
(source: https://legacy-documentation-sdks.temporal.io/typescript/data-converters)

If you read this inversely and (think contrapositive) then one can say that you CAN send values that ARE JSON-serializible and the number type is listed as json-serilazible here -> https://en.wikipedia.org/wiki/JSON#Data_types

**Second change:** we simply add a span to the tracing so which projects and their IDS get sampled/cleaned-up can be observed in the tracing tool