### PR TITLE
chore(gc): parameters are JSON serializable

### DIFF
--- a/js/spec/binary-client.spec.ts
+++ b/js/spec/binary-client.spec.ts
@@ -112,14 +112,14 @@ describe("binary client operations", () => {
   });
 
   it("can gc random-projects and return the count cleaned up", async () => {
-    const result = await binaryClient.gcRandomProjects(90, 2n, -1n, { timeout: 90 });
+    const result = await binaryClient.gcRandomProjects(90, 2, -1, { timeout: 90 });
 
     expect(JSON.stringify(result)).toMatch('{"count":0}');
     expect(result.count).toStrictEqual(0);
   });
 
   it("can gc a specific project and return the count cleaned up", async () => {
-    const result = await binaryClient.gcProject(1n, 2n, -1n, { timeout: 90 });
+    const result = await binaryClient.gcProject(1, 2, -1, { timeout: 90 });
 
     expect(JSON.stringify(result)).toMatch('{"count":0}');
     expect(result.count).toStrictEqual(0);

--- a/js/src/binary-client.ts
+++ b/js/src/binary-client.ts
@@ -253,7 +253,7 @@ export class DateiLagerBinaryClient {
    * @param options         dict options passed
    * @param options.timeout timeout limit for the request
    */
-  public async gcRandomProjects(sample: number, keep: bigint, from?: bigint, options?: { timeout?: number }): Promise<GCResult> {
+  public async gcRandomProjects(sample: number, keep: number, from?: number, options?: { timeout?: number }): Promise<GCResult> {
     return await trace(
       "dateilager-binary-client.gc",
       {
@@ -284,12 +284,12 @@ export class DateiLagerBinaryClient {
    * @param options         dict options passed
    * @param options.timeout timeout limit for the request
    */
-  public async gcProject(project: bigint, keep: bigint, from?: bigint, options?: { timeout?: number }): Promise<GCResult> {
+  public async gcProject(project: number, keep: number, from?: number, options?: { timeout?: number }): Promise<GCResult> {
     return await trace(
       "dateilager-binary-client.gc",
       {
         attributes: {
-          "db.mode": "mode",
+          "db.mode": "project",
           "dl.keep": String(keep),
           "dl.from": String(from),
         },


### PR DESCRIPTION
Similar to [this PR](https://github.com/gadget-inc/dateilager/pull/45) the change done here is related to the workflows in gadget. 

It turns out that not only do activity outputs need to be JSON serializable, but so do inputs. And as such this PR changes the parameters from bigint (not json serializable) to number.