### PR TITLE
Add getcache command

### DIFF
--- a/pkg/cli/cache.go
+++ b/pkg/cli/cache.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/logger"
+	"github.com/gadget-inc/dateilager/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdGetCache() *cobra.Command {
+	var (
+		path string
+	)
+
+	cmd := &cobra.Command{
+		Use: "getcache",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			c := client.FromContext(ctx)
+
+			version, err := c.GetCache(ctx, path)
+			if err != nil {
+				return err
+			}
+
+			logger.Info(ctx, "cache built", key.Version.Field(version))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "Cache directory")
+
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -70,6 +70,10 @@ func NewClientCommand() *cobra.Command {
 
 			ctx, span = telemetry.Start(ctx, "cmd.main")
 
+			if server == "" {
+				return fmt.Errorf("required flag(s) \"server\" not set")
+			}
+
 			cl, err := client.NewClient(ctx, server)
 			if err != nil {
 				return err
@@ -100,6 +104,7 @@ func NewClientCommand() *cobra.Command {
 	cmd.AddCommand(NewCmdSnapshot())
 	cmd.AddCommand(NewCmdUpdate())
 	cmd.AddCommand(NewCmdGc())
+	cmd.AddCommand(NewCmdGetCache())
 
 	return cmd
 }


### PR DESCRIPTION
Adds the ability to call the `GetCache` command from the CLI.

Not needed in prod yet but is useful for manually fetching a DL cache.