### PR TITLE
Hardlink from cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ SERVICE := $(PROJECT).server
 .PHONY: install migrate migrate-create clean build lint release
 .PHONY: test test-one test-fuzz test-js lint-js build-js
 .PHONY: reset-db setup-local server server-profile install-js
-.PHONY: client-update client-large-update client-get client-rebuild client-pack
-.PHONY: client-gc-contents client-gc-project client-gc-random-projects
+.PHONY: client-update client-large-update client-get client-rebuild client-rebuild-with-cache
+.PHONY: client-getcache client-gc-contents client-gc-project client-gc-random-projects
 .PHONY: health upload-container-image gen-docs
 .PHONY: load-test-new load-test-get load-test-update
 
@@ -162,6 +162,16 @@ ifndef to_version
 else
 	go run cmd/client/main.go rebuild --server $(GRPC_SERVER) --project 1 --to $(to_version) --prefix "$(prefix)" --dir $(dir)
 endif
+
+client-rebuild-with-cache: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+client-rebuild-with-cache: export DL_SKIP_SSL_VERIFICATION=1
+client-rebuild-with-cache:
+	go run cmd/client/main.go rebuild --server $(GRPC_SERVER) --project 1 --prefix "$(prefix)" --dir $(dir) --cachedir input/cache
+
+client-getcache: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
+client-getcache: export DL_SKIP_SSL_VERIFICATION=1
+client-getcache:
+	go run cmd/client/main.go getcache --server $(GRPC_SERVER) --path input/cache
 
 client-gc-contents: export DL_TOKEN=$(DEV_TOKEN_ADMIN)
 client-gc-contents: export DL_SKIP_SSL_VERIFICATION=1

--- a/test/client_rebuild_test.go
+++ b/test/client_rebuild_test.go
@@ -254,8 +254,10 @@ func TestRebuildWithCache(t *testing.T) {
 	bCachePath := filepath.Join(client.CacheObjectsDir(cacheDir), hb.Hex(), "pack/b")
 
 	verifyDir(t, tmpDir, 1, map[string]expectedFile{
-		"pack/a": {fileType: typeSymlink, content: aCachePath},
-		"pack/b": {fileType: typeSymlink, content: bCachePath},
+		"pack/a/1": {content: "pack/a/1 v1"},
+		"pack/a/2": {content: "pack/a/2 v1"},
+		"pack/b/1": {content: "pack/b/1 v1"},
+		"pack/b/2": {content: "pack/b/2 v1"},
 	})
 
 	assertFileContent := func(path string, expectedContent string) {


### PR DESCRIPTION
Today when we reference files in the shared cache we use symlinks.

However, Node really doesn't deal well with symlinks in it's `node_modules` directory, see here for more info: https://pnpm.io/faq#why-have-hard-links-at-all-why-not-symlink-directly-to-the-global-store

So let's try using hardlinks instead. Since you cannot hardlink a directory we need to walk the dir and hardlink each file individually. This seems to work fine when linking symlinks.

The way to tell a file has been hardlinked is via the inode counter shown with `ls -l`.