### PR TITLE
Change/insecure ts client

### DIFF
--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -88,6 +88,7 @@ export class DateiLagerGrpcClient {
       "grpc.keepalive_timeout_ms": 1_000,
       "grpc.keepalive_permit_without_calls": 1,
       "grpc.lb_policy_name": "round_robin", //added this guy yay but can be passed below as a grpcClientOptions via the options
+      "grpc.ssl_target_name_override": "dateilager.gadget-services.net",
       ...options.grpcClientOptions,
     };
 
@@ -105,7 +106,7 @@ export class DateiLagerGrpcClient {
       })
     )
 
-    const clusterIP = "dateilager-headless.dateilager-production.svc.cluster.local"
+    const clusterIP = "dateilager-headless.dateilager-production.svc.cluster.local:5051"
     this._transport = new GrpcTransport({
       host: clusterIP,
       channelCredentials,

--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions } from "@grpc/grpc-js";
-import { Channel, ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
+import { ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
 import type { Span } from "@opentelemetry/api";
 import { context as contextAPI, trace as traceAPI } from "@opentelemetry/api";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
@@ -19,18 +19,18 @@ export interface DateiLagerGrpcClientOptions {
    * The address of the dateilager server.
    */
   server:
-    | string
-    | {
-        /**
-         * The host of the dateilager server.
-         */
-        host: string;
+  | string
+  | {
+    /**
+     * The host of the dateilager server.
+     */
+    host: string;
 
-        /**
-         * The port of the dateilager server.
-         */
-        port: number;
-      };
+    /**
+     * The port of the dateilager server.
+     */
+    port: number;
+  };
 
   /**
    * The token that will be sent as authorization metadata to the dateilager server.
@@ -63,7 +63,7 @@ export class DateiLagerGrpcClient {
   private readonly _client: FsClient;
 
   /** @internal */
-  private readonly _transport: GrpcTransport;
+  readonly _transport: GrpcTransport;
 
   /** @internal */
   private readonly _rpcOptions: () => RpcOptions | undefined;
@@ -80,7 +80,7 @@ export class DateiLagerGrpcClient {
     this._transport = new GrpcTransport({
       host: typeof options.server === "string" ? options.server : `${options.server.host}:${options.server.port}`,
       channelCredentials: credentials.combineChannelCredentials(
-        ChannelCredentials.createInsecure(),
+        ChannelCredentials.createSsl(),
         credentials.createFromMetadataGenerator((_, callback) => {
           tokenFn()
             .then((token) => {

--- a/js/src/grpc-client.ts
+++ b/js/src/grpc-client.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions } from "@grpc/grpc-js";
-import { ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
+import { Channel, ChannelCredentials, credentials, Metadata } from "@grpc/grpc-js";
 import type { Span } from "@opentelemetry/api";
 import { context as contextAPI, trace as traceAPI } from "@opentelemetry/api";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
@@ -80,7 +80,7 @@ export class DateiLagerGrpcClient {
     this._transport = new GrpcTransport({
       host: typeof options.server === "string" ? options.server : `${options.server.host}:${options.server.port}`,
       channelCredentials: credentials.combineChannelCredentials(
-        ChannelCredentials.createSsl(),
+        ChannelCredentials.createInsecure(),
         credentials.createFromMetadataGenerator((_, callback) => {
           tokenFn()
             .then((token) => {


### PR DESCRIPTION

const dl = require("./js/dist/cjs/grpc-client.js");
const info = {server: {host: 'dateilager-storage-7b98758cd9-lsn49.dateilager-headless.dateilager-production.svc.cluster.local', port: 5051}, token: "v2.public.eyJzdWIiOiJhZG1pbiIsImlhdCI6IjIwMjItMDMtMDFUMjE6NDY6NTQuMTQ0WiJ9S_1eCGugJkhzrczDT-jnjmL3iTuQAg4HJBrNANFh3RYK61Yiis0K2NXtrJhzG20ojeCG4Qsf9Q6rQ9e-N8w8CA", grpcClientOptions: {"grpc.ssl_target_name_override": "dateilager.gadget-services.net"}};
const client = new dl.DateiLagerGrpcClient(info);

await client._client.listProjects();