### PR TITLE
Re-use a pool of buffers

### DIFF
--- a/internal/buffers/buffers.go
+++ b/internal/buffers/buffers.go
@@ -1,0 +1,28 @@
+package buffers
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bufferPool = &sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+func Get() *bytes.Buffer {
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func GetWith(bs []byte) *bytes.Buffer {
+	buf := Get()
+	buf.Write(bs)
+	return buf
+}
+
+func Put(buf *bytes.Buffer) {
+	bufferPool.Put(buf)
+}

--- a/internal/db/query.go
+++ b/internal/db/query.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gadget-inc/dateilager/internal/buffers"
 	"github.com/gadget-inc/dateilager/internal/pb"
 	"github.com/jackc/pgx/v5"
 )
@@ -80,9 +81,12 @@ func NewVersionRange(ctx context.Context, tx pgx.Tx, project int64, from *int64,
 }
 
 func unpackObjects(content []byte) ([]*pb.Object, error) {
+	buf := buffers.GetWith(content)
+	defer buffers.Put(buf)
+
 	var objects []*pb.Object
 	tarReader := NewTarReader()
-	tarReader.FromBytes(content)
+	tarReader.FromBuffer(buf)
 
 	for {
 		header, err := tarReader.Next()

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/gadget-inc/dateilager/internal/buffers"
 	"github.com/gadget-inc/dateilager/internal/pb"
 	"github.com/jackc/pgx/v5"
 
@@ -169,8 +170,10 @@ func TestGetCacheWithMultipleVersions(t *testing.T) {
 		if err == db.SKIP {
 			continue
 		}
+
+		buf := buffers.GetWith(tar)
 		tarReader := db.NewTarReader()
-		tarReader.FromBytes(tar)
+		tarReader.FromBuffer(buf)
 
 		for {
 			header, err := tarReader.Next()
@@ -189,6 +192,8 @@ func TestGetCacheWithMultipleVersions(t *testing.T) {
 
 			paths = append(paths, header.Name)
 		}
+
+		buffers.Put(buf)
 	}
 	assert.Equal(t, []string{"pack/a", "pack/b"}, paths)
 }


### PR DESCRIPTION
I noticed we create a new `bytes.Buffer` inside our `TarReader.FromBytes` function. This PR adds a global pool of buffers and replaces `TarReader.FromBytes` with `TarReader.FromBuffer`.

_NOTE: I didn't perf test these changes 😬_