### PR TITLE
Take update lock after receiving streaming messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Start DateiLager server
         run: make server &
 
+      - name: Wait for DateiLager server
+        run: sleep 5
+
       - name: Run fuzz tests
         run: make test-fuzz
 
@@ -71,6 +74,9 @@ jobs:
 
       - name: Start DateiLager server
         run: make server &
+
+      - name: Wait for DateiLager server
+        run: sleep 5
 
       - name: Run JS tests
         run: make test-js

--- a/internal/db/update.go
+++ b/internal/db/update.go
@@ -38,22 +38,6 @@ func DeleteObject(ctx context.Context, tx pgx.Tx, project int64, version int64, 
 	return nil
 }
 
-func DeleteObjects(ctx context.Context, tx pgx.Tx, project int64, version int64, path string) error {
-	pathPredicate := fmt.Sprintf("%s%%", path)
-	_, err := tx.Exec(ctx, `
-		UPDATE dl.objects
-		SET stop_version = $1
-		WHERE project = $2
-		  AND path LIKE $3
-		  AND stop_version IS NULL
-	`, version, project, pathPredicate)
-	if err != nil {
-		return fmt.Errorf("delete objects, project %v, version %v, path %v: %w", project, version, pathPredicate, err)
-	}
-
-	return nil
-}
-
 // UpdateObject returns true if content changed, false otherwise
 func UpdateObject(ctx context.Context, tx pgx.Tx, encoder *ContentEncoder, project int64, version int64, object *pb.Object) (bool, error) {
 	content := object.Content

--- a/test/client_rebuild_test.go
+++ b/test/client_rebuild_test.go
@@ -451,7 +451,6 @@ func TestRebuildFileBecomesADir(t *testing.T) {
 	defer close()
 
 	tmpDir := emptyTmpDir(t)
-	fmt.Printf("tmpdir located at %s\n", tmpDir)
 	defer os.RemoveAll(tmpDir)
 
 	rebuild(tc, c, 1, i(1), tmpDir, nil, expectedResponse{


### PR DESCRIPTION
We currently take the update row lock right as an Update request comes in.

We then stream every object in and update PG after each message. Once we've received all of the objects only then do we grab the lock and start updating PG.

This PR leaves room for more batching in PG, but that change can be done in a follow up PR.

We are trading higher memory usage (the need to buffer all objects in memory) for lower lock times. But we were already buffering all packed objects, which is often the majority of the size, so I think this should be fine.