### PR TITLE
TarReader reuse buffer

### DIFF
--- a/internal/db/tar.go
+++ b/internal/db/tar.go
@@ -137,22 +137,26 @@ func (o *TarObject) TarType() byte {
 }
 
 type TarReader struct {
+	buffer    *bytes.Buffer
 	s2Reader  *s2.Reader
 	tarReader *tar.Reader
 }
 
 func NewTarReader() *TarReader {
-	var buffer bytes.Buffer
-	s2Reader := s2.NewReader(&buffer)
+	buffer := &bytes.Buffer{}
+	s2Reader := s2.NewReader(buffer)
 
 	return &TarReader{
+		buffer:    buffer,
 		s2Reader:  s2Reader,
 		tarReader: tar.NewReader(s2Reader),
 	}
 }
 
 func (t *TarReader) FromBytes(content []byte) {
-	t.s2Reader.Reset(bytes.NewBuffer(content))
+	t.buffer.Reset()
+	t.buffer.Write(content)
+	t.s2Reader.Reset(t.buffer)
 	t.tarReader = tar.NewReader(t.s2Reader)
 }
 

--- a/test/client_rebuild_test.go
+++ b/test/client_rebuild_test.go
@@ -451,7 +451,6 @@ func TestRebuildFileBecomesADir(t *testing.T) {
 	defer close()
 
 	tmpDir := emptyTmpDir(t)
-	fmt.Printf("tmpdir located at %s\n", tmpDir)
 	defer os.RemoveAll(tmpDir)
 
 	rebuild(tc, c, 1, i(1), tmpDir, nil, expectedResponse{


### PR DESCRIPTION
Instead of using a buffer pool, what if we just use the same buffer for the lifetime of the `TarReader`.

This should work because we can re-use a `TarReader` in the couple of spots where we instantiate it. We use a similar tactic for the `TarWriter`.