### PR TITLE
Insert into the contents table outside the transaction

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type CloseFunc func(context.Context)
 
 type DbConnector interface {
+	Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error)
 	Connect(context.Context) (pgx.Tx, CloseFunc, error)
 }

--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -584,7 +584,7 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 				shouldUpdateVersion = true
 			} else {
 				var contentChanged bool
-				contentChanged, err = db.UpdateObject(ctx, tx, contentEncoder, project, nextVersion, object)
+				contentChanged, err = db.UpdateObject(ctx, tx, f.DbConn, contentEncoder, project, nextVersion, object)
 
 				if contentChanged {
 					shouldUpdateVersion = true
@@ -611,7 +611,7 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 				key.ObjectsCount.Field(len(objects)),
 			)
 
-			contentChanged, err := db.UpdatePackedObjects(ctx, tx, project, nextVersion, parent, objects)
+			contentChanged, err := db.UpdatePackedObjects(ctx, tx, f.DbConn, project, nextVersion, parent, objects)
 			if err != nil {
 				return status.Errorf(codes.Internal, "FS update packed objects for %v: %v", parent, err)
 			}


### PR DESCRIPTION
While working on parallel fixture loading gadget side, I encountered a number of dl project update failures caused by concurrent project updates deadlocking in DL's postgres. They look like this:

```
[2:58:36.496 PM] FATAL (dl-client) <cli/client.go:136>: command failed
    serverRole: "api"
    userVisible: false
    source: "platform"
    userspaceLogLevel: 20
    commandKey: "ServerOperation-oxYccZkKAEMY"
    trace_id: "27a3aa62d00cd3c96c4cd13788d52069"
    span_id: "1ae79b985ca4e495"
    trace_flags: "01"
    stacktrace: "github.com/gadget-inc/dateilager/pkg/cli.ClientExecute\n\tgithub.com/gadget-inc/dateilager/pkg/cli/client.go:136\nmain.main\n\tgithub.com/gadget-inc/dateilager/cmd/client/main.go:6\nruntime.main\n\truntime/proc.go:250"
    error: {
      "message": "update objects: close and receive fs.Update: rpc error: code = Internal desc = FS update packed objects for node_modules/string-similarity/: insert packed content, hash 5c910ba26299c8c3b9cfc5a4ca9b7734-9e3a52a5898872a8235f76467d6ef074: ERROR: deadlock detected (SQLSTATE 40P01)"
    }
```

I think that `ON CONFLICT DO NOTHING` helps resolve two writes happening at the same time for the same object, but if two transactions write different objects in opposite orders, they can still deadlock I believe.

Conveniently, I think that the contents table can actually be non-atomically committed to. Rows in it are immutable and garbage collected out of band already, so I think we can actually just add to the contents table outside the transaction. We ensure the contents are aded before the objects referencing them are, so we should never have objects referencing contents that don't exist. We might now have contents that aren't referenced by any objects as the contents committed but the objects didn't, but I think that's ok. It also means the performance sensitive objects transactions take fewer locks and ideally can commit quicker.

Vibing?
