### PR TITLE
suppress errors from Cobra

### DIFF
--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -41,6 +41,7 @@ func NewClientCommand() *cobra.Command {
 		Short:             "DateiLager client",
 		DisableAutoGenTag: true,
 		Version:           version.Version,
+		SilenceErrors:     true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true // silence usage when an error occurs after flags have been parsed
 


### PR DESCRIPTION
In our observability stack we detected that we were emitting the logging twice for the same event and cause. After further investigation and recreating this locally
<img width="1288" alt="CleanShot 2023-12-14 at 15 56 01@2x" src="https://github.com/gadget-inc/dateilager/assets/30190842/da83fc64-5a81-4da5-8aa1-4b54340825b7">

We can confirm we are double logging. After some investigation it became clear that cobra takes it upon itself to log errors coming out of CLI events it handles.  Furthermore, cobra doesn't respect or even know about our log-encoding resulting in this problem. Luckily they provide a flag to suppress these logs.

As such this PR introduces this flag to be true so we don't have to see double logging anymore and can now just see the proper JSON logging we want from `Zap`


after the flag is set...
<img width="1441" alt="CleanShot 2023-12-14 at 16 08 25@2x" src="https://github.com/gadget-inc/dateilager/assets/30190842/195a554e-fbc7-46bc-80cf-6246843f0e77">


🎩 
1. Have the flag set to false or not set at all
2. Change the `client-gc-project` command in the makefile to `--keep 0` (this will error)
3. run that command `make client-gc-project` and see the error being logged twice
4. Now set the flag and run client-gc-project again and confirm you see just the JSON error