### PR TITLE
Don't terminate DL binary client subprocesses when the parent process is SIGTERM'd

### DIFF
--- a/js/src/binary-client.ts
+++ b/js/src/binary-client.ts
@@ -374,6 +374,7 @@ export class DateiLagerBinaryClient {
     }
     const subprocess = execa(this._options.command, baseArgs.concat(args), {
       cwd,
+      cleanup: false, // don't terminate this subprocess process eagerly when the parent process is terminated, which is execa's default behaviour. we use graceful shutdown gadget-side to give running operations a chance to complete, and we don't want to terminate them prematurely
       timeout: options?.timeout ?? this._options.timeout[method],
       env: { DL_TOKEN: await this._options.token() },
     });


### PR DESCRIPTION
We were seeing failures in Gadget during deploys where a running pod would be doing DL work and get SIGTERM'd by kubernetes. Normally, unixes will only deliver that signal to the parent process, but `execa` takes care to propagate SIGTERMs from the parent to any spawned children. This has the effect of prematurely killing a dl binary client subprocess mid operation. We use graceful shutdown in gadget to allow currently-running operations within our workers to finish, and so to allow that, we don't want these signals propagated.