### PR TITLE
Only copy live objects

### DIFF
--- a/internal/db/copy.go
+++ b/internal/db/copy.go
@@ -23,6 +23,7 @@ func CopyAllObjects(ctx context.Context, tx pgx.Tx, source int64, target int64) 
 		SELECT $1, start_version, stop_version, path, hash, mode, size, packed
 		FROM dl.objects
 		WHERE project = $2
+		AND stop_version IS NULL
 	`, target, source)
 	if err != nil {
 		return fmt.Errorf("copy project, source %v, target %v: %w", source, target, err)

--- a/test/fs_test.go
+++ b/test/fs_test.go
@@ -53,6 +53,10 @@ func TestNewProjectWithTemplate(t *testing.T) {
 		"/b": {content: "b v3"},
 		"/c": {content: "c v3"},
 	})
+
+	// Copied projects should only contain live objects
+	assert.Equal(t, 4, countObjectsByProject(tc, 1))
+	assert.Equal(t, 2, countObjectsByProject(tc, 2))
 }
 
 func TestGetEmpty(t *testing.T) {

--- a/test/shared_test.go
+++ b/test/shared_test.go
@@ -110,6 +110,20 @@ func countContents(tc util.TestCtx) int {
 	return count
 }
 
+func countObjectsByProject(tc util.TestCtx, project int64) int {
+	conn := tc.Connect()
+
+	var count int
+	err := conn.QueryRow(tc.Context(), `
+		SELECT count(*)
+		FROM dl.objects
+		WHERE project = $1
+	`, project).Scan(&count)
+	require.NoError(tc.T(), err, "count objects")
+
+	return count
+}
+
 func writeObjectFull(tc util.TestCtx, project int64, start int64, stop *int64, path, content string, mode fs.FileMode) {
 	conn := tc.Connect()
 


### PR DESCRIPTION
When we copy a project using a template (this is how we create new environments or fork a project) we were copying all objects.

Now this just copies live objects (an object where `stop_version IS null`).