### PR TITLE
Add a prerelease github workflow for building and publishing unfinished versions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,28 @@
+name: Prerelease
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup golang environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --clean -f .goreleaser.prerelease.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,0 +1,47 @@
+builds:
+  - main: ./cmd/client/main.go
+    id: client
+    binary: client
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version=v{{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - main: ./cmd/server/main.go
+    id: server
+    binary: server
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version=v{{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        - tar -zcf dist/migrations.tar.gz migrations
+
+changelog:
+  skip: true
+
+checksum:
+  name_template: "checksums.txt"
+  extra_files:
+    - glob: ./dist/migrations.tar.gz
+
+archives:
+  - name_template: "{{ .ProjectName }}-v{{ .Version }}-PRERELEASE-{{ .Os }}-{{ .Arch }}"
+  
+
+release:
+  prerelease: true
+  extra_files:
+    - glob: ./dist/migrations.tar.gz


### PR DESCRIPTION
This adds a new github workflow triggered by a button press that prereleases with goreleaser. This lets us publish all the built artifacts for downstream usage in Gadget's staging / canary environments with the same nice, already-maintained publishing pipeline 👍 