### PR TITLE
Add DL agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 registry.fedoraproject.org/fedora-minimal:40
 
-RUN microdnf install -y curl findutils gzip iputils less postgresql procps shadow-utils tar time which \
+RUN microdnf install -y curl findutils gzip hostname iputils less postgresql procps shadow-utils tar time which \
     && microdnf clean all
 
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.23 \
@@ -19,7 +19,9 @@ WORKDIR /home/main
 RUN mkdir -p /home/main/secrets
 VOLUME /home/main/secrets/tls
 VOLUME /home/main/secrets/paseto
+VOLUME /home/main/varlib
 
+COPY release/client_linux_amd64 client
 COPY release/server_linux_amd64 server
 COPY migrations migrations
 COPY entrypoint.sh entrypoint.sh

--- a/internal/files/writer.go
+++ b/internal/files/writer.go
@@ -90,7 +90,7 @@ func writeObject(rootDir string, cacheObjectsDir string, reader *db.TarReader, h
 			return err
 		}
 		hashHex := hex.EncodeToString(content)
-		return hardlinkDir(filepath.Join(cacheObjectsDir, hashHex, header.Name), path)
+		return HardlinkDir(filepath.Join(cacheObjectsDir, hashHex, header.Name), path)
 
 	case tar.TypeReg:
 		dir := filepath.Dir(path)
@@ -193,7 +193,7 @@ func makeSymlink(oldname, newname string) error {
 	return nil
 }
 
-func hardlinkDir(olddir, newdir string) error {
+func HardlinkDir(olddir, newdir string) error {
 	if fileExists(newdir) {
 		err := os.RemoveAll(newdir)
 		if err != nil {

--- a/k8s/agent.yaml
+++ b/k8s/agent.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dl-agent
+  labels:
+    app: dl-agent
+spec:
+  selector:
+    matchLabels:
+      app: dl-agent
+  template:
+    metadata:
+      name: dl-agent
+      labels:
+        app: dl-agent
+    spec:
+      containers:
+        - name: agent
+          image: local/dateilager:latest
+          imagePullPolicy: Never
+          securityContext: # FIXME
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          command: ["./client"]
+          args:
+            [
+              "agent",
+              "--host=dl-headless.dateilager.svc.cluster.local",
+              "--headless-host=dl-headless.dateilager.svc.cluster.local",
+              "--dir=/home/main/varlib/dl_cache",
+              "--log-level=info",
+              "--log-encoding=json",
+            ]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            failureThreshold: 2
+          env:
+            - name: DL_SKIP_SSL_VERIFICATION
+              value: "1"
+          envFrom:
+            - secretRef:
+                name: dl-agent-secrets
+          volumeMounts:
+            - name: varlib
+              mountPath: /home/main/varlib
+      volumes:
+        - name: varlib
+          hostPath:
+            path: /var/lib
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dl-agent
+  labels:
+    app: dl-agent
+spec:
+  internalTrafficPolicy: Local
+  selector:
+    app: dl-agent
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dateilager

--- a/k8s/sandbox.yaml
+++ b/k8s/sandbox.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dl-sandbox
+  labels:
+    app: dl-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dl-sandbox
+  template:
+    metadata:
+      name: dl-sandbox
+      labels:
+        app: dl-sandbox
+    spec:
+      containers:
+        - name: sandbox
+          image: local/dateilager:latest
+          imagePullPolicy: Never
+          command: ["bash", "-c", "--"]
+          args: ["while true; do sleep 30; done;"]
+          # command: ["bash"]
+          # args:
+          #   [
+          #     "-c",
+          #     'curl -XPOST -H ''Content-Type: application/json'' -d "{\"uid\":\"${K8S_CONTAINER_ID}\", \"volume\": \"appdir\"}"  dl-agent.dateilager.svc.cluster.local:8080/link_cache',
+          #   ]
+          env:
+            - name: K8S_CONTAINER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          volumeMounts:
+            - name: appdir
+              mountPath: /tmp/appdir
+      volumes:
+        - name: appdir
+          emptyDir: {}

--- a/k8s/server.yaml
+++ b/k8s/server.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dl-server
+  labels:
+    app: dl-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dl-server
+  template:
+    metadata:
+      name: dl-server
+      labels:
+        app: dl-server
+    spec:
+      containers:
+        - name: server
+          image: local/dateilager:latest
+          imagePullPolicy: Never
+          command: ["./server"]
+          args:
+            [
+              "--log-level=info",
+              "--log-encoding=json",
+              "--port=5051",
+              "--dburi=$(DATABASE_URL)",
+              "--cert=secrets/tls/tls.crt",
+              "--key=secrets/tls/tls.key",
+              "--paseto=secrets/paseto/paseto.pub",
+            ]
+          ports:
+            - name: api
+              containerPort: 5051
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                [
+                  "/bin/grpc_health_probe",
+                  "-addr=:5051",
+                  "-service=dateilager.server",
+                  "-tls",
+                  "-tls-no-verify",
+                ]
+            initialDelaySeconds: 1
+          livenessProbe:
+            exec:
+              command:
+                [
+                  "/bin/grpc_health_probe",
+                  "-addr=:5051",
+                  "-service=dateilager.server",
+                  "-tls",
+                  "-tls-no-verify",
+                ]
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            failureThreshold: 2
+          env:
+            - name: DL_ENV
+              value: "dev"
+          envFrom:
+            - secretRef:
+                name: dl-app-secrets
+          volumeMounts:
+            - mountPath: "/home/main/secrets/tls"
+              name: tls-secret
+            - mountPath: "/home/main/secrets/paseto"
+              name: paseto-secret
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: dl-tls-secret
+        - name: paseto-secret
+          secret:
+            secretName: dl-paseto-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dl-headless
+  name: dl-headless
+spec:
+  clusterIP: None
+  selector:
+    app: dl-server
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 5051
+      targetPort: 5051

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+
+	"github.com/gadget-inc/dateilager/internal/files"
+	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/logger"
+	"go.uber.org/zap"
+)
+
+type Agent struct {
+	varlibDir string
+	cacheDir  string
+	port      int
+}
+
+func NewAgent(cacheDir, varlibDir string, port int) Agent {
+	return Agent{varlibDir, cacheDir, port}
+}
+
+func (a *Agent) Server(ctx context.Context) *http.Server {
+	http.HandleFunc("GET /healthz", a.healthCheck)
+	http.HandleFunc("POST /link_cache", a.linkCache)
+
+	server := &http.Server{
+		Addr:        ":" + strconv.Itoa(a.port),
+		BaseContext: func(net.Listener) context.Context { return ctx },
+	}
+	return server
+}
+
+type healthStatus struct {
+	Status string `json:"status"`
+}
+
+func (a *Agent) healthCheck(resp http.ResponseWriter, req *http.Request) {
+	err := json.NewEncoder(resp).Encode(healthStatus{Status: "OK"})
+	if err != nil {
+		httpErr(req.Context(), resp, err, "failed to encode status")
+		return
+	}
+}
+
+type linkRequest struct {
+	Uid    string `json:"uid"`
+	Volume string `json:"volume"`
+}
+
+func (a *Agent) linkCache(resp http.ResponseWriter, req *http.Request) {
+	linkReq := linkRequest{}
+	err := json.NewDecoder(req.Body).Decode(&linkReq)
+	if err != nil {
+		httpReqErr(req.Context(), resp, err, "failed to decode link request")
+		return
+	}
+
+	volumePath := filepath.Join(a.varlibDir, "kubelet/pods", linkReq.Uid, "volumes/kubernetes.io~empty-dir", linkReq.Volume)
+
+	logger.Info(req.Context(), "linking cache directory", key.Directory.Field(filepath.Join(volumePath, "dl_cache")), zap.String("cacheDir", a.cacheDir))
+
+	err = files.HardlinkDir(a.cacheDir, filepath.Join(volumePath, "dl_cache"))
+	if err != nil {
+		httpErr(req.Context(), resp, err, "failed to link cache director")
+		return
+	}
+
+	resp.WriteHeader(http.StatusCreated)
+}
+
+func httpReqErr(ctx context.Context, resp http.ResponseWriter, err error, message string) {
+	logger.Warn(ctx, message, zap.Error(err))
+	http.Error(resp, err.Error(), http.StatusBadRequest)
+}
+
+func httpErr(ctx context.Context, resp http.ResponseWriter, err error, message string) {
+	logger.Error(ctx, message, zap.Error(err))
+	http.Error(resp, err.Error(), http.StatusInternalServerError)
+}

--- a/pkg/cli/agent.go
+++ b/pkg/cli/agent.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/logger"
+	"github.com/gadget-inc/dateilager/pkg/agent"
+	"github.com/gadget-inc/dateilager/pkg/client"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func NewCmdAgent() *cobra.Command {
+	var (
+		dir  string
+		port int
+	)
+
+	cmd := &cobra.Command{
+		Use: "agent",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			c := client.FromContext(ctx)
+
+			// Wait for the server to be available
+			version := int64(-1)
+			var err error
+
+			for i := 0; i < 20; i++ {
+				version, err = c.GetCache(ctx, dir)
+				if err != nil {
+					logger.Error(ctx, "get cache err", zap.Error(err))
+					parentErr := errors.Unwrap(err)
+					statusErr, ok := status.FromError(parentErr)
+					if ok {
+						if statusErr.Code() == codes.Unavailable {
+							time.Sleep(3 * time.Second)
+							continue
+						}
+					}
+					return err
+				}
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+
+			logger.Info(ctx, "cache downloaded", key.Version.Field(version), key.Directory.Field(dir))
+
+			a := agent.NewAgent("/home/main/varlib", dir, port)
+
+			backgroundCtx, cancel := context.WithCancel(ctx)
+			server := a.Server(backgroundCtx)
+
+			osSignals := make(chan os.Signal, 1)
+			signal.Notify(osSignals, os.Interrupt, syscall.SIGTERM)
+
+			go func() {
+				<-osSignals
+				logger.Info(ctx, "received interrupt signal")
+
+				cancel()
+
+				err := server.Shutdown(ctx)
+				if err != nil {
+					logger.Error(ctx, "error shutting down server", zap.Error(err))
+				}
+			}()
+
+			logger.Info(ctx, "start agent", zap.Int("port", port), key.Directory.Field(dir))
+			return server.ListenAndServe()
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", "", "Cache directory")
+	cmd.Flags().IntVar(&port, "port", 8080, "API server port")
+
+	_ = cmd.MarkFlagRequired("path")
+
+	return cmd
+}

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -84,6 +84,7 @@ func NewClientCommand() *cobra.Command {
 				return fmt.Errorf("required flag(s) \"host\" not set")
 			}
 
+			logger.Info(ctx, "client config", zap.String("host", host), zap.Uint16("port", port), zap.String("headlesshost", headlessHost))
 			cl, err := client.NewClient(ctx, host, port, client.WithheadlessHost(headlessHost))
 			if err != nil {
 				return err
@@ -124,6 +125,7 @@ func NewClientCommand() *cobra.Command {
 	cmd.AddCommand(NewCmdUpdate())
 	cmd.AddCommand(NewCmdGc())
 	cmd.AddCommand(NewCmdGetCache())
+	cmd.AddCommand(NewCmdAgent())
 
 	return cmd
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gadget-inc/dateilager/internal/db"
 	"github.com/gadget-inc/dateilager/internal/files"
 	"github.com/gadget-inc/dateilager/internal/key"
+	"github.com/gadget-inc/dateilager/internal/logger"
 	"github.com/gadget-inc/dateilager/internal/pb"
 	"github.com/gadget-inc/dateilager/internal/telemetry"
 	fsdiff_pb "github.com/gadget-inc/fsdiff/pkg/pb"
@@ -758,6 +759,8 @@ func (c *Client) GetCache(ctx context.Context, cacheRootDir string) (int64, erro
 		return -1, fmt.Errorf("fs.GetCache receive: %w", err)
 	}
 	version := response.Version
+
+	logger.Info(ctx, "get cache version", key.Version.Field(version), key.CacheVersions.Field(availableVersions))
 
 	for _, availableVersion := range availableVersions {
 		if version == availableVersion {


### PR DESCRIPTION
A design for the agent and the K8S tooling necessary to run it locally with Docker desktop.

```
$ make setup-k8s
$ make deploy-k8s
```

Connect to the demo sandbox pod:

```
$ kubectl --context docker-desktop -n dateilager exec -it dl-sandbox-bbfb85548-r92vg -- bash
bash-5.2$ curl dl-agent.dateilager.svc.cluster.local:8080/healthz
{"status":"OK"}
bash-5.2$ curl -XPOST -H 'Content-Type: application/json' -d "{\"uid\":\"${K8S_CONTAINER_ID}\", \"volume\": \"appdir\"}"  dl-agent.dateilager.svc.cluster.local:8080/link_cache
```

And it is currently failing with:

```
ln /home/main/varlib/cni/cache/results/cni-loopback-00d359d08d903c13c8e918d44f02db2f2b81084e298d39bbd0818392d9f6fdcc-eth0 /tmp/dl_cache_k8s/kubelet/pods/5c7ee044-ba3a-4b8a-b25b-b192d4f85eec/volumes/kubernetes.io~projected/appdir/dl_cache/cni/cache/results/cni-loopback-00d359d08d903c13c8e918d44f02db2f2b81084e298d39bbd0818392d9f6fdcc-eth0: link /home/main/varlib/cni/cache/results/cni-loopback-00d359d08d903c13c8e918d44f02db2f2b81084e298d39bbd0818392d9f6fdcc-eth0 /tmp/dl_cache_k8s/kubelet/pods/5c7ee044-ba3a-4b8a-b25b-b192d4f85eec/volumes/kubernetes.io~projected/appdir/dl_cache/cni/cache/results/cni-loopback-00d359d08d903c13c8e918d44f02db2f2b81084e298d39bbd0818392d9f6fdcc-eth0: invalid cross-device link
```