### PR TITLE
Fixup prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,8 +1,9 @@
 name: Prerelease
 
 on:
-  workflow_dispatch:
-
+  push:
+    tags:
+      - "*-pre.*"
 defaults:
   run:
     shell: bash -l {0}
@@ -18,24 +19,32 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.22"
-
+      - name: Check for tag
+        run: |
+          if [[ -z "${{ github.ref_name }}" ]]; then
+            echo "No tag found, use make prerelease to create a tag"
+            exit 1
+          fi
+      - name: Set env var for tag
+        run: echo "CUSTOM_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean --snapshot -f .goreleaser.prerelease.yml
+          args: release --clean --snapshot -f .goreleaser.prerelease.yml 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          CUSTOM_VERSION: ${{ env.CUSTOM_VERSION }}
       - name: Create prerelease
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "pre-${{ github.sha }}"
+          tag_name: ${{ env.CUSTOM_VERSION }}
           prerelease: true
           make_latest: false
-          name: "Prelease: pre-${{ github.sha }}"
+          name: "Prelease: ${{ env.CUSTOM_VERSION }}"
           files: |
             dist/*.tar.gz
             dist/checksum*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   push:
     tags:
       - v*
+      - "!v*pre*"
 
 defaults:
   run:

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ tmp/*
 
 .vscode/*
 !.vscode/settings.example.json
-!.vscode/tasks.json
-!.vscode/launch.json
+!.vscode/tasks.example.json
+!.vscode/launch.example.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   enable:
     - errcheck
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocritic
     - gofmt

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - main: ./cmd/client/main.go
     id: client
@@ -5,7 +6,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version=v{{.Version}}
+      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version={{.Env.CUSTOM_VERSION}}
     goos:
       - linux
       - darwin
@@ -18,7 +19,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version=v{{.Version}}
+      - -s -w -X github.com/gadget-inc/dateilager/pkg/version.Version={{.Env.CUSTOM_VERSION}}
     goos:
       - linux
       - darwin
@@ -30,7 +31,7 @@ builds:
         - tar -zcf dist/migrations.tar.gz migrations
 
 changelog:
-  skip: true
+  disable: true
 
 checksum:
   name_template: "checksums.txt"
@@ -38,7 +39,7 @@ checksum:
     - glob: ./dist/migrations.tar.gz
 
 archives:
-  - name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}-{{ .Env.CUSTOM_VERSION }}-{{ .Os }}-{{ .Arch }}"
 
 release:
   extra_files:

--- a/.vscode/launch.example.json
+++ b/.vscode/launch.example.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}"
+        },
+        {
+            "name": "Debug Cached CSI Tests",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/test",
+            "env": {
+                "DB_URI": "postgres://postgres:password@127.0.0.1:5432/dl_tests",
+                "DB_USER": "postgres",
+                "DB_PASS": "password",
+                "DB_HOST": "127.0.0.1",
+                "RUN_WITH_SUDO": "true"
+            },
+            "preLaunchTask": "migrate",
+            "showLog": true
+        }
+    ]
+}

--- a/.vscode/tasks.example.json
+++ b/.vscode/tasks.example.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "migrate",
+            "type": "shell",
+            "command": "make migrate",
+            "options": {
+                "env": {
+                    "DB_URI": "postgres://postgres:password@127.0.0.1:5432/dl_tests"
+                },
+            },
+            "presentation": {
+                "reveal": "silent"
+            }
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MIGRATE_DIR := ./migrations
 SERVICE := $(PROJECT).server
 BENCH_PROFILE ?= ""
 
-.PHONY: migrate migrate-create clean build lint release
+.PHONY: migrate migrate-create clean build lint release prerelease
 .PHONY: test test-one test-fuzz test-js lint-js install-js build-js
 .PHONY: reset-db setup-local build-cache-version server server-profile cached
 .PHONY: client-update client-large-update client-get client-rebuild client-rebuild-with-cache
@@ -93,6 +93,20 @@ release: release/server_linux_amd64 release/server_macos_amd64 release/server_ma
 release: release/client_linux_amd64 release/client_macos_amd64 release/client_macos_arm64 release/client_linux_arm64
 release: release/cached_linux_amd64 release/cached_macos_amd64 release/cached_macos_arm64 release/cached_linux_arm64
 release: release/migrations.tar.gz
+
+prerelease: build
+prerelease:
+ifndef tag
+	$(error tag variable must be set)
+else
+	git tag -f v$(tag) $(shell git rev-parse HEAD)
+endif
+ifndef force
+	git push origin $(shell git branch --show-current)
+else
+	git push origin +$(shell git branch --show-current)
+endif
+	git push origin v$(tag)
 
 test: export DB_URI = postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/dl_tests
 test: migrate

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,8 @@ prerelease:
 ifndef tag
 	$(error tag variable must be set)
 else
-	git tag -f v$(tag) $(shell git rev-parse HEAD)
+	cd js && npx ts-node dateilager-prerelease.ts -t "$(tag)"
 endif
-ifndef force
-	git push origin $(shell git branch --show-current)
-else
-	git push origin +$(shell git branch --show-current)
-endif
-	git push origin v$(tag)
 
 test: export DB_URI = postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/dl_tests
 test: migrate

--- a/js/dateilager-prerelease.ts
+++ b/js/dateilager-prerelease.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S  node --import @swc-node/register/esm-register
+import fs from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+//Define interface for package.json structure
+interface PackageJson {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+  name: string;
+  version: string;
+}
+
+// Path to package.json (defaults to current directory)
+const packagePath: string = path.resolve(process.cwd(), 'package.json');
+
+// Get the current git commit SHA
+function getGitCommitSha(): string {
+  try {
+    // Execute git command to get the current commit SHA
+    const sha: string = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    // Return only the first 7 characters
+    return sha.substring(0, 7);
+  } catch (error) {
+    console.error('Error getting git commit SHA:', (error as Error).message);
+    process.exit(1);
+  }
+}
+
+function preReleaseVersion(baseVersion: string): string {
+  const sha = getGitCommitSha();  
+  return `v${baseVersion}-pre.${sha}`;
+}
+
+// Read and update package.json
+function updatePackageVersion(version: string): void {
+  try {
+    // Read the package.json file
+    const packageData: string = fs.readFileSync(packagePath, 'utf8');
+    const packageJson: PackageJson = JSON.parse(packageData) as PackageJson; 
+
+    // Store the original version for logging
+    const originalVersion: string = packageJson.version;
+    
+    // Update the version with the git SHA
+    packageJson.version = version;
+    
+    // Write the updated package.json back to file
+    fs.writeFileSync(
+      packagePath,
+      JSON.stringify(packageJson, null, 2) + '\n',
+      'utf8'
+    );
+    
+    console.log(`Package version updated from "${originalVersion}" to "${version}"`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.error(`Error: ${packagePath} not found`);
+    } else {
+      console.error('Error updating package.json:', (error as Error).message);
+    }
+    process.exit(1);
+  }
+}
+
+function tagGit(version: string): void {
+  try {
+    execSync(`git tag -f ${version} $(git rev-parse HEAD)`, { stdio: 'inherit' });
+    execSync(`git push origin ${version}`, { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Error tagging git:', (error as Error).message);
+    process.exit(1);
+  }
+}
+
+function publishPreReleaseToGithub(): void {
+  execSync(`npm run prerelease`, { stdio: 'inherit' });
+}
+
+function doPreRelease(): void {
+  console.log(`Running prerelease with version: ${process.argv.toString()}`);
+  const args = yargs(hideBin(process.argv))
+    .option('t', {
+      description: 'Version tag to release',
+      type: 'string',
+      alias: 'version-tag',
+      demandOption: true
+    })
+    .help()
+    .argv;
+  
+  console.log(`Running prerelease with version: ${args.t}`);
+
+  const version = preReleaseVersion(args.t);
+  console.log(`Setting prerelease version to: ${version}`);
+  
+  tagGit(version); // To kick off the prerelease build
+
+  // Update the package version and publish to github
+  updatePackageVersion(version);
+  publishPreReleaseToGithub();
+
+  console.log(`Prerelease version ${version} published`);
+  console.warn(`The package.json version has been updated and is now ${version}`);
+}   
+
+// Run the function
+if (require.main === module) {
+  doPreRelease();
+}

--- a/js/dateilager-prerelease.ts
+++ b/js/dateilager-prerelease.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S  node --import @swc-node/register/esm-register
-import fs from 'fs';
-import { execSync } from 'child_process';
-import path from 'path';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 //Define interface for package.json structure
 interface PackageJson {
@@ -14,23 +14,23 @@ interface PackageJson {
 }
 
 // Path to package.json (defaults to current directory)
-const packagePath: string = path.resolve(process.cwd(), 'package.json');
+const packagePath: string = path.resolve(process.cwd(), "package.json");
 
 // Get the current git commit SHA
 function getGitCommitSha(): string {
   try {
     // Execute git command to get the current commit SHA
-    const sha: string = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    const sha: string = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
     // Return only the first 7 characters
     return sha.substring(0, 7);
   } catch (error) {
-    console.error('Error getting git commit SHA:', (error as Error).message);
+    console.error("Error getting git commit SHA:", (error as Error).message);
     process.exit(1);
   }
 }
 
 function preReleaseVersion(baseVersion: string): string {
-  const sha = getGitCommitSha();  
+  const sha = getGitCommitSha();
   return `v${baseVersion}-pre.${sha}`;
 }
 
@@ -38,28 +38,24 @@ function preReleaseVersion(baseVersion: string): string {
 function updatePackageVersion(version: string): void {
   try {
     // Read the package.json file
-    const packageData: string = fs.readFileSync(packagePath, 'utf8');
-    const packageJson: PackageJson = JSON.parse(packageData) as PackageJson; 
+    const packageData: string = fs.readFileSync(packagePath, "utf8");
+    const packageJson: PackageJson = JSON.parse(packageData) as PackageJson;
 
     // Store the original version for logging
     const originalVersion: string = packageJson.version;
-    
+
     // Update the version with the git SHA
     packageJson.version = version;
-    
+
     // Write the updated package.json back to file
-    fs.writeFileSync(
-      packagePath,
-      JSON.stringify(packageJson, null, 2) + '\n',
-      'utf8'
-    );
-    
+    fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + "\n", "utf8");
+
     console.log(`Package version updated from "${originalVersion}" to "${version}"`);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       console.error(`Error: ${packagePath} not found`);
     } else {
-      console.error('Error updating package.json:', (error as Error).message);
+      console.error("Error updating package.json:", (error as Error).message);
     }
     process.exit(1);
   }
@@ -67,35 +63,34 @@ function updatePackageVersion(version: string): void {
 
 function tagGit(version: string): void {
   try {
-    execSync(`git tag -f ${version} $(git rev-parse HEAD)`, { stdio: 'inherit' });
-    execSync(`git push origin ${version}`, { stdio: 'inherit' });
+    execSync(`git tag -f ${version} $(git rev-parse HEAD)`, { stdio: "inherit" });
+    execSync(`git push origin ${version}`, { stdio: "inherit" });
   } catch (error) {
-    console.error('Error tagging git:', (error as Error).message);
+    console.error("Error tagging git:", (error as Error).message);
     process.exit(1);
   }
 }
 
 function publishPreReleaseToGithub(): void {
-  execSync(`npm run prerelease`, { stdio: 'inherit' });
+  execSync(`npm run prerelease`, { stdio: "inherit" });
 }
 
 function doPreRelease(): void {
   console.log(`Running prerelease with version: ${process.argv.toString()}`);
   const args = yargs(hideBin(process.argv))
-    .option('t', {
-      description: 'Version tag to release',
-      type: 'string',
-      alias: 'version-tag',
-      demandOption: true
+    .option("t", {
+      description: "Version tag to release",
+      type: "string",
+      alias: "version-tag",
+      demandOption: true,
     })
-    .help()
-    .argv;
-  
+    .help().argv;
+
   console.log(`Running prerelease with version: ${args.t}`);
 
   const version = preReleaseVersion(args.t);
   console.log(`Setting prerelease version to: ${version}`);
-  
+
   tagGit(version); // To kick off the prerelease build
 
   // Update the package version and publish to github
@@ -104,7 +99,7 @@ function doPreRelease(): void {
 
   console.log(`Prerelease version ${version} published`);
   console.warn(`The package.json version has been updated and is now ${version}`);
-}   
+}
 
 // Run the function
 if (require.main === module) {

--- a/js/gitpkg.config.js
+++ b/js/gitpkg.config.js
@@ -1,8 +1,8 @@
 const { execSync } = require("child_process");
 
-module.exports = () => ({ 
+module.exports = () => ({
   getTagName: (pkg) => {
-    if (!pkg.version.includes('pre')) {
+    if (!pkg.version.includes("pre")) {
       console.error(`Version ${pkg.version} does not include 'pre', please use 'make prerelease'`);
       process.exit(1);
     }

--- a/js/gitpkg.config.js
+++ b/js/gitpkg.config.js
@@ -1,5 +1,11 @@
 const { execSync } = require("child_process");
 
-module.exports = () => ({
-  getTagName: (pkg) => `${pkg.name}-v${pkg.version}-gitpkg-${execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim()}`,
+module.exports = () => ({ 
+  getTagName: (pkg) => {
+    if (!pkg.version.includes('pre')) {
+      console.error(`Version ${pkg.version} does not include 'pre', please use 'make prerelease'`);
+      process.exit(1);
+    }
+    return `${pkg.name}-${pkg.version}-gitpkg`;
+  },
 });

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -35,7 +35,8 @@
         "pg": "^8.9.0",
         "prettier": "^2.8.8",
         "prettier-plugin-packagejson": "^2.2.18",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "yargs": "^17.7.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/js/package.json
+++ b/js/package.json
@@ -57,6 +57,7 @@
     "pg": "^8.9.0",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.2.18",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "yargs": "^17.7.2"
   }
 }

--- a/js/tsconfig.eslint.json
+++ b/js/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "*.js", ".eslintrc.js"],
+  "include": ["src", "*.js", ".eslintrc.js", "dateilager-prerelease.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Consolidated the pre-release process into a single ts script that keeps all of the different version tags in sync and plays nice with how the gadget code base expects it. This aligns with the versioning of an actual release.

This pulls the `prerelease` changes out of #107 so that it's clearer.