### PR TITLE
Batch up all deletes/updates in an Update API call

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,4 +13,5 @@ type DbConnector interface {
 	Connect(context.Context) (pgx.Tx, CloseFunc, error)
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 	Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error)
+	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
 }

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -62,6 +62,14 @@ func (d *DbTestConnector) Exec(ctx context.Context, sql string, args ...interfac
 	}
 }
 
+func (d *DbTestConnector) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+	if d.innerTx != nil {
+		return d.innerTx.CopyFrom(ctx, tableName, columnNames, rowSrc)
+	} else {
+		return d.tx.CopyFrom(ctx, tableName, columnNames, rowSrc)
+	}
+}
+
 func (d *DbTestConnector) close(ctx context.Context) {
 	_ = d.tx.Rollback(ctx)
 	d.conn.Close(ctx)

--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -509,7 +509,7 @@ func (f *Fs) GetUnary(ctx context.Context, req *pb.GetUnaryRequest) (*pb.GetUnar
 	return &response, nil
 }
 
-// nolint:gocyclo // we should try to break this one up, but ignoring for now
+//nolint:gocyclo // we should try to break this one up, but ignoring for now
 func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 	ctx := stream.Context()
 

--- a/pkg/api/fs.go
+++ b/pkg/api/fs.go
@@ -509,6 +509,7 @@ func (f *Fs) GetUnary(ctx context.Context, req *pb.GetUnaryRequest) (*pb.GetUnar
 	return &response, nil
 }
 
+// nolint:gocyclo // we should try to break this one up, but ignoring for now
 func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 	ctx := stream.Context()
 
@@ -522,9 +523,6 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 		return status.Errorf(codes.Unavailable, "FS db connection unavailable: %v", err)
 	}
 	defer close(ctx)
-
-	contentEncoder := db.NewContentEncoder()
-	defer contentEncoder.Close()
 
 	var packManager *db.PackManager
 
@@ -583,6 +581,9 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 		return stream.SendAndClose(&pb.UpdateResponse{Version: -1})
 	}
 
+	contentEncoder := db.NewContentEncoder()
+	defer contentEncoder.Close()
+
 	latestVersion := int64(-1)
 	nextVersion := int64(-1)
 	shouldUpdateVersion := false
@@ -599,27 +600,42 @@ func (f *Fs) Update(stream pb.Fs_UpdateServer) error {
 		nextVersion = latestVersion + 1
 		logger.Info(ctx, "FS.Update[Init]", key.Project.Field(project), key.Version.Field(nextVersion))
 
+		var deletedPaths []string
+		var objectsToUpdate []*pb.Object
 		for _, object := range objectBuffer {
-			logger.Debug(ctx, "FS.Update[Object]",
-				key.Project.Field(project),
-				key.Version.Field(nextVersion),
-				key.ObjectPath.Field(object.Path),
-			)
-
 			if object.Deleted {
-				err = db.DeleteObject(ctx, tx, project, nextVersion, object.Path)
-				shouldUpdateVersion = true
+				logger.Debug(ctx, "FS.Delete[Object]",
+					key.Project.Field(project),
+					key.Version.Field(nextVersion),
+					key.ObjectPath.Field(object.Path),
+				)
+				deletedPaths = append(deletedPaths, object.Path)
 			} else {
-				var contentChanged bool
-				contentChanged, err = db.UpdateObject(ctx, tx, f.DbConn, contentEncoder, project, nextVersion, object)
-
-				if contentChanged {
-					shouldUpdateVersion = true
-				}
+				logger.Debug(ctx, "FS.Update[Object]",
+					key.Project.Field(project),
+					key.Version.Field(nextVersion),
+					key.ObjectPath.Field(object.Path),
+				)
+				objectsToUpdate = append(objectsToUpdate, object)
 			}
+		}
 
+		if len(deletedPaths) > 0 {
+			err = db.DeleteObjects(ctx, tx, project, nextVersion, deletedPaths)
 			if err != nil {
 				return status.Errorf(codes.Internal, "FS update: %v", err)
+			}
+			shouldUpdateVersion = true
+		}
+
+		if len(objectsToUpdate) > 0 {
+			contentChanged, err := db.UpdateObjects(ctx, tx, f.DbConn, contentEncoder, project, nextVersion, objectsToUpdate)
+			if err != nil {
+				return status.Errorf(codes.Internal, "FS update: %v", err)
+			}
+
+			if contentChanged {
+				shouldUpdateVersion = true
 			}
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,6 +127,10 @@ func (d *DbPoolConnector) Exec(ctx context.Context, sql string, args ...interfac
 	return d.pool.Exec(ctx, sql, args...)
 }
 
+func (d *DbPoolConnector) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rows pgx.CopyFromSource) (int64, error) {
+	return d.pool.CopyFrom(ctx, tableName, columnNames, rows)
+}
+
 type Server struct {
 	Grpc   *grpc.Server
 	Health *health.Server


### PR DESCRIPTION
Closes https://github.com/gadget-inc/dateilager/issues/106

Previously, when an update call was issued to dateilager, we would run a set of queries for every object being updated. This resulted in A LOT of DB chatter. For example, during application creating in Gadget:

![CleanShot 2025-03-20 at 10 25 50@2x](https://github.com/user-attachments/assets/8723dbdd-5c3a-4423-8d02-d5394076a769)

You can see 1000s of pgx spans are nested under `update-objects` and `update-packed-objects`. This PR fixes that by bulk inserting. Since we have a dynamic number of objects to insert, we can't do a regular INSERT due to potential limitations on the number of parameters. Instead, we use another trick: create a temporary table that is dropped after the transaction completes where we stage all of the updates, and use `COPY` to efficiently get data into it.

The end result is pretty good!

![CleanShot 2025-03-20 at 10 29 20@2x](https://github.com/user-attachments/assets/9246ea72-38a7-4900-ac0f-d749bd4fd3ee)

Ignoring the packed objects update (discussion below), the regular update call goes from 1k+ queries taking 289ms to 6 calls taking 44ms. I'll have to benchmark a bunch, but on average I'm thinking this could be close to an order of magnitude improvement. Hard to talk specifics, but it's also likely going to be a big win for the production DB too, since it has to deal with less chatter.

## Topics of conversation

First, the regular update works really well, but I still need to investigate what's making the packed objects version so slow. It's specifically the `CopyFrom` call, but I would have suspected that to be significantly faster.

Second, there were some comments about doing certain things outside of a transaction to avoid deadlocks. I don't do that any more, but I suspect we'll be okay because we do everything in single statements. The comments mentioned deadlocks were observed in tests, but I didn't observe any issues with a Gadget-side PR using a DL built from this branch for testing.

Finally, we likely now need to load a bunch more stuff into memory at once. Assuming I can make the packed objects query have gains similar to the update, how do we feel about that? If we're feeling a bit uncomfy, I can set it all up to batch `CopyFrom` calls so that we stay within some amount of memory per call.