### PR TITLE
Allow the ability to set a user

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@
 
 buildGoModule rec {
   pname = "dateilager";
-  version = "0.9.2";
+  version = "0.9.3-pre.b557094";
   src = ./.;
   proxyVendor = true; # Fixes: cannot query module due to -mod=vendor running make install
   vendorHash = "sha256-e7qQgdF1vkQyl0dc3FnO94sgShwcZC3ntQHcjyLxt7k=";

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gadgetinc/dateilager",
-  "version": "0.9.2",
+  "version": "0.9.3-pre.b557094",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gadgetinc/dateilager",
-      "version": "0.9.2",
+      "version": "0.9.3-pre.b557094",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.6",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/dateilager",
-  "version": "0.9.2",
+  "version": "0.9.3-pre.b557094",
   "homepage": "https://github.com/gadget-inc/dateilager",
   "bugs": "https://github.com/gadget-inc/dateilager/issues",
   "repository": {

--- a/pkg/api/cached.go
+++ b/pkg/api/cached.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -31,6 +32,7 @@ const (
 	CACHE_PATH_SUFFIX = "dl_cache"
 	UPPER_DIR         = "upper"
 	WORK_DIR          = "work"
+	NO_CHANGE_USER    = -1
 )
 
 type Cached struct {
@@ -154,6 +156,19 @@ func (c *Cached) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Volume Capability must be provided")
 	}
 
+	volumeAttributes := req.GetVolumeContext()
+	var appUser int
+	var appGroup int
+	var err error
+	if appUser, err = strconv.Atoi(volumeAttributes["appUser"]); err != nil {
+		appUser = NO_CHANGE_USER
+	}
+
+	// If only appUser is provided, use the same value for appGroup
+	if appGroup, err = strconv.Atoi(volumeAttributes["appGroup"]); err != nil {
+		appGroup = appUser
+	}
+
 	targetPath := req.GetTargetPath()
 	// The parent of the target path and can store CSI metadata, it's the name given to the volume mount in the pod spec
 	volumePath := path.Join(targetPath, "..")
@@ -161,7 +176,7 @@ func (c *Cached) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	// Perform an overlay mount
 	upperdir := path.Join(volumePath, UPPER_DIR)
-	err := os.MkdirAll(upperdir, 0777)
+	err = os.MkdirAll(upperdir, 0777)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create overlay upper directory %s: %v", upperdir, err)
 	}
@@ -170,6 +185,7 @@ func (c *Cached) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat overlay upper directory %s: %v", upperdir, err)
 	}
+
 	if upperInfo.Mode()&os.ModePerm != 0777 {
 		err = os.Chmod(upperdir, 0777)
 		if err != nil {
@@ -232,6 +248,24 @@ func (c *Cached) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	err = os.MkdirAll(path.Join(targetPath, "app"), 0777)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create app directory %s: %v", path.Join(targetPath, "app"), err)
+	}
+
+	err = os.Chown(path.Join(targetPath, "app"), appUser, appGroup)
+	if err != nil {
+		stat, newErr := os.Stat(targetPath)
+		if newErr != nil {
+			return nil, fmt.Errorf("failed to stat target path %s: %v", targetPath, newErr)
+		}
+		sysstat := stat.Sys().(*syscall.Stat_t)
+		fmt.Printf("target path owner uid=%d gid=%d\n", sysstat.Uid, sysstat.Gid)
+
+		stat, newErr = os.Stat(path.Join(targetPath, "app"))
+		if newErr != nil {
+			return nil, fmt.Errorf("failed to stat app directory %s: %v", path.Join(targetPath, "app"), newErr)
+		}
+		sysstat = stat.Sys().(*syscall.Stat_t)
+		fmt.Printf("app path owner uid=%d gid=%d\n", sysstat.Uid, sysstat.Gid)
+		return nil, fmt.Errorf("failed to chown app directory %s: %v", path.Join(targetPath, "app"), err)
 	}
 
 	err = os.Chmod(path.Join(targetPath, "app"), 0777)

--- a/pkg/api/cached.go
+++ b/pkg/api/cached.go
@@ -256,10 +256,12 @@ func (c *Cached) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	}
 
 	// For testing where we're not running as root, we need to chown the app dir via the command line :(
-	if appUser != NO_CHANGE_USER && os.Getenv("RUN_WITH_SUDO") == "true" {
-		err = execCommand("chown", "-R", fmt.Sprintf("%d:%d", appUser, appGroup), path.Join(targetPath, "app"))
-	} else {
-		err = os.Chown(path.Join(targetPath, "app"), appUser, appGroup)
+	if appUser != NO_CHANGE_USER {
+		if os.Getenv("RUN_WITH_SUDO") == "true" {
+			err = execCommand("chown", "-R", fmt.Sprintf("%d:%d", appUser, appGroup), path.Join(targetPath, "app"))
+		} else {
+			err = os.Chown(path.Join(targetPath, "app"), appUser, appGroup)
+		}
 	}
 
 	if err != nil {

--- a/test/cached_csi_test.go
+++ b/test/cached_csi_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"syscall"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -284,6 +285,60 @@ func TestCachedCSIDriverMountCanDoAFullRebuild(t *testing.T) {
 	})
 
 }
+
+func TestCachedCSIDriverAppUserSet(t *testing.T) {
+	tc := util.NewTestCtx(t, auth.Project, 1)
+	defer tc.Close()
+
+	writeProject(tc, 1, 4)
+	writeObject(tc, 1, 1, nil, "a", "a v1")
+	writeObject(tc, 1, 2, i(3), "b", "b v2")
+	writeObject(tc, 1, 3, i(4), "b/c", "b/c v3")
+	writeObject(tc, 1, 3, nil, "b/d", "b/d v3")
+	writeObject(tc, 1, 4, nil, "b/e", "b/e v4")
+
+	tmpDir := emptyTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	cached, _, close := createTestCachedServer(tc, tmpDir)
+	defer close()
+
+	err := cached.Prepare(tc.Context())
+	require.NoError(t, err, "cached.Prepare must succeed")
+
+	targetDir := path.Join(tmpDir, "vol-target")
+
+	stagingDir := path.Join(tmpDir, "vol-staging-target")
+	_, err = cached.NodePublishVolume(tc.Context(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "foobar",
+		StagingTargetPath: stagingDir,
+		TargetPath:        targetDir,
+		VolumeCapability:  &csi.VolumeCapability{},
+		VolumeContext: map[string]string{
+			"appUser":  "1000",
+			"appGroup": "1000",
+		},
+	})
+	require.NoError(t, err)
+
+	c, _, close := createTestClient(tc)
+	defer close()
+
+	appDir := path.Join(targetDir, "app")
+	dlCacheDir := path.Join(targetDir, "dl_cache")
+
+	// Do the initial build
+	rebuild(tc, c, 1, i(1), appDir, &dlCacheDir, expectedResponse{
+		version: 1,
+		count:   1,
+	}, nil)
+
+	appUser, err := os.Stat(appDir)
+	require.NoError(t, err)
+	require.Equal(t, 1000, appUser.Sys().(syscall.Stat_t).Uid)
+	require.Equal(t, 1000, appUser.Sys().(syscall.Stat_t).Gid)
+}
+
 func formatFileMode(mode os.FileMode) string {
 	return fmt.Sprintf("%#o", mode)
 }

--- a/test/cached_csi_test.go
+++ b/test/cached_csi_test.go
@@ -335,8 +335,10 @@ func TestCachedCSIDriverAppUserSet(t *testing.T) {
 
 	appUser, err := os.Stat(appDir)
 	require.NoError(t, err)
-	require.Equal(t, 1000, appUser.Sys().(syscall.Stat_t).Uid)
-	require.Equal(t, 1000, appUser.Sys().(syscall.Stat_t).Gid)
+
+	sysstat := appUser.Sys().(*syscall.Stat_t)
+	require.Equal(t, 1000, int(sysstat.Uid))
+	require.Equal(t, 1000, int(sysstat.Gid))
 }
 
 func formatFileMode(mode os.FileMode) string {


### PR DESCRIPTION
We currently have an issue where the app dir is now owned by root instead of by the api user, this change allows us to pass in the container user to the csi driver and we set the app dir to that.