### PR TITLE
reflinks if available

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,26 +18,28 @@ runs:
         echo "go_mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
         echo "go_build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "npm=$(npm config get cache)" >> $GITHUB_OUTPUT
+        echo "go_sum_hash=${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+        echo "npm_lock_hash=${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
       shell: bash -l {0}
 
     - name: Cache Go mods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.cache-paths.outputs.go_mod }}
           ${{ steps.cache-paths.outputs.go_build }}
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ steps.cache-paths.outputs.go_sum_hash }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          ${{ steps.cache-paths.outputs.go_sum_hash }}
           ${{ runner.os }}-go-
 
     - name: Cache npm packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.cache-paths.outputs.npm }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ steps.cache-paths.outputs.npm_lock_hash }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          ${{ steps.cache-paths.outputs.npm_lock_hash }}
           ${{ runner.os }}-node-
 
     - name: Download Go modules

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,9 +9,25 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  test:
+  test-integration:
+    strategy:
+      matrix:
+        filesystem: [ext4, xfs]
     runs-on: ubuntu-latest
     steps:
+      - name: Setup XFS filesystem
+        if: matrix.filesystem == 'xfs'
+        run: |
+          cd /
+          sudo apt-get update
+          sudo apt-get install -y xfsprogs util-linux
+          sudo mkdir -p /mnt/xfs
+          sudo dd if=/dev/zero of=/mnt/xfs.img bs=2G count=10
+          sudo mkfs.xfs /mnt/xfs.img
+          sudo mount -o loop /mnt/xfs.img $GITHUB_WORKSPACE
+          sudo chown $USER:$USER $GITHUB_WORKSPACE
+          findmnt
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -26,6 +42,13 @@ jobs:
 
       - name: Build Go binaries
         run: make build
+
+      - name: Use XFS for tmpdirs
+        if: matrix.filesystem == 'xfs'
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/tmp
+          export TMPDIR=$GITHUB_WORKSPACE/tmp
+          echo "TMPDIR=$GITHUB_WORKSPACE/tmp" >> $GITHUB_ENV
 
       - name: Run Go tests
         run: make test-integration

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -19,8 +19,6 @@ jobs:
         if: matrix.filesystem == 'xfs'
         run: |
           cd /
-          sudo apt-get update
-          sudo apt-get install -y xfsprogs util-linux
           sudo mkdir -p /mnt/xfs
           sudo dd if=/dev/zero of=/mnt/xfs.img bs=2G count=10
           sudo mkfs.xfs /mnt/xfs.img

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,29 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        filesystem: [ext4, xfs]
     steps:
+      - name: Setup XFS filesystem
+        if: matrix.filesystem == 'xfs'
+        run: |
+          cd /
+          sudo apt-get update
+          sudo apt-get install -y xfsprogs util-linux
+          sudo mkdir -p /mnt/xfs
+          sudo dd if=/dev/zero of=/mnt/xfs.img bs=2G count=10
+          sudo mkfs.xfs /mnt/xfs.img
+          sudo mount -o loop /mnt/xfs.img $GITHUB_WORKSPACE
+          sudo chown $USER:$USER $GITHUB_WORKSPACE
+          findmnt
+
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Setup development environment
         uses: ./.github/actions/setup-env
+
 
       - name: Start background services
         run: dev &
@@ -26,6 +43,13 @@ jobs:
 
       - name: Build Go binaries
         run: make build
+
+      - name: Use XFS for tmpdirs
+        if: matrix.filesystem == 'xfs'
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/tmp
+          export TMPDIR=$GITHUB_WORKSPACE/tmp
+          echo "TMPDIR=$GITHUB_WORKSPACE/tmp" >> $GITHUB_ENV
 
       - name: Run Go tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
         if: matrix.filesystem == 'xfs'
         run: |
           cd /
-          sudo apt-get update
-          sudo apt-get install -y xfsprogs util-linux
           sudo mkdir -p /mnt/xfs
           sudo dd if=/dev/zero of=/mnt/xfs.img bs=2G count=10
           sudo mkfs.xfs /mnt/xfs.img

--- a/docs/client/client.md
+++ b/docs/client/client.md
@@ -13,13 +13,16 @@ DateiLager client
       --tracing               Whether tracing is enabled
 ```
 
+### Environment variables
+
+You can make Dateilager always use reflink support from the underlying filesystem with the `FORCE_REFLINKS=true` environment variable. If you want to disable support for reflinks even if a filesystem supports them, you can also set `FORCE_REFLINKS=never`.
+
 ### SEE ALSO
 
-* [client get](client_get.md)	 - 
-* [client inspect](client_inspect.md)	 - 
-* [client new](client_new.md)	 - 
-* [client rebuild](client_rebuild.md)	 - 
-* [client reset](client_reset.md)	 - 
-* [client snapshot](client_snapshot.md)	 - 
-* [client update](client_update.md)	 - 
-
+- [client get](client_get.md) -
+- [client inspect](client_inspect.md) -
+- [client new](client_new.md) -
+- [client rebuild](client_rebuild.md) -
+- [client reset](client_reset.md) -
+- [client snapshot](client_snapshot.md) -
+- [client update](client_update.md) -

--- a/internal/files/reflink.go
+++ b/internal/files/reflink.go
@@ -4,6 +4,7 @@ package files
 
 import (
 	"errors"
+	"io/fs"
 )
 
 // reflinkFile performs the actual reflink action using the FICLONE ioctl
@@ -12,6 +13,6 @@ import (
 //
 // This operation requires both files to be on the same filesystem that supports
 // reflinks (like btrfs or xfs with reflink=1 mount option).
-func reflinkFile(source, target string) error {
+func reflinkFile(source, target string, perm fs.FileMode) error {
 	return errors.New("reflink failed: not supported on this platform")
 }

--- a/internal/files/reflink.go
+++ b/internal/files/reflink.go
@@ -1,0 +1,17 @@
+//go:build !linux && !darwin
+
+package files
+
+import (
+	"errors"
+)
+
+// reflinkFile performs the actual reflink action using the FICLONE ioctl
+// without handling any fallback mechanism. On Linux, this uses the FICLONE ioctl
+// which efficiently creates a copy-on-write clone of the entire source file.
+//
+// This operation requires both files to be on the same filesystem that supports
+// reflinks (like btrfs or xfs with reflink=1 mount option).
+func reflinkFile(source, target string) error {
+	return errors.New("reflink failed: not supported on this platform")
+}

--- a/internal/files/reflink_darwin.go
+++ b/internal/files/reflink_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package files
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// reflinkFile performs the actual reflink action using the clonefile syscall
+// without handling any fallback mechanism. On Darwin, this uses the clonefile syscall
+// which efficiently creates a copy-on-write clone of the entire source file.
+//
+// This operation requires both files to be on the same filesystem that supports
+// reflinks (like APFS).
+func reflinkFile(source, target string) error {
+	err := unix.Clonefile(source, target, unix.CLONE_NOFOLLOW)
+	if err != nil {
+		if err == unix.ENOTSUP || err == unix.EXDEV {
+			return fmt.Errorf("reflink not supported: %w", err)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/internal/files/reflink_linux.go
+++ b/internal/files/reflink_linux.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package files
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// reflinkFile performs the actual reflink action using the FICLONE ioctl
+// without handling any fallback mechanism. On Linux, this uses the FICLONE ioctl
+// which efficiently creates a copy-on-write clone of the entire source file.
+//
+// This operation requires both files to be on the same filesystem that supports
+// reflinks (like btrfs or xfs with reflink=1 mount option).
+func reflinkFile(source, target string) error {
+	s, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	ss, err := s.SyscallConn()
+	if err != nil {
+		return err
+	}
+	sd, err := d.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var err2, err3 error
+
+	err = sd.Control(func(dfd uintptr) {
+		err2 = ss.Control(func(sfd uintptr) {
+			// int ioctl(int dest_fd, FICLONE, int src_fd);
+			err3 = unix.IoctlFileClone(int(dfd), int(sfd))
+		})
+	})
+
+	if err != nil {
+		// sd.Control failed
+		return err
+	}
+	if err2 != nil {
+		// ss.Control failed
+		return err2
+	}
+
+	if err3 != nil && errors.Is(err3, unix.ENOTSUP) {
+		return errors.New("reflink failed: not supported on this filesystem")
+	}
+
+	// err3 is ioctl() response
+	return err3
+}

--- a/internal/files/writer.go
+++ b/internal/files/writer.go
@@ -397,6 +397,14 @@ func WriteTar(finalDir string, cacheObjectsDir string, reader *db.TarReader, pac
 // HasReflinkSupport checks if the given directory supports reflinks.
 // It attempts to create a reflink in the directory and returns true if successful.
 func HasReflinkSupport(dir string) bool {
+	forceReflinks := os.Getenv("FORCE_REFLINKS")
+	if forceReflinks == "never" {
+		return false
+	}
+	if forceReflinks != "" {
+		return true
+	}
+
 	srcFile := filepath.Join(dir, "reflink_test_src")
 	dstFile := filepath.Join(dir, "reflink_test_dst")
 	os.Remove(srcFile)

--- a/internal/files/writer.go
+++ b/internal/files/writer.go
@@ -80,7 +80,7 @@ func retryFileErrors[R any](path string, fn retryableFileOperation[R]) (R, error
 	return result, err
 }
 
-func writeObject(rootDir string, cacheObjectsDir string, reader *db.TarReader, header *tar.Header, existingDirs map[string]bool) (bool, error) {
+func writeObject(rootDir string, cacheObjectsDir string, reader *db.TarReader, header *tar.Header, existingDirs map[string]bool, hasReflinkSupport bool) (bool, error) {
 	path := filepath.Join(rootDir, header.Name)
 
 	switch header.Typeflag {
@@ -90,7 +90,11 @@ func writeObject(rootDir string, cacheObjectsDir string, reader *db.TarReader, h
 			return false, err
 		}
 		hashHex := hex.EncodeToString(content)
-		return true, HardlinkDir(filepath.Join(cacheObjectsDir, hashHex, header.Name), path)
+		if hasReflinkSupport {
+			return true, ReflinkDir(filepath.Join(cacheObjectsDir, hashHex, header.Name), path)
+		} else {
+			return true, HardlinkDir(filepath.Join(cacheObjectsDir, hashHex, header.Name), path)
+		}
 
 	case tar.TypeReg:
 		dir := filepath.Dir(path)
@@ -248,7 +252,95 @@ func HardlinkDir(olddir, newdir string) error {
 	})
 }
 
-func WriteTar(finalDir string, cacheObjectsDir string, reader *db.TarReader, packPath *string, matcher *FileMatcher) (uint32, uint32, bool, error) {
+func ReflinkDir(olddir, newdir string) error {
+	if fileExists(newdir) {
+		err := os.RemoveAll(newdir)
+		if err != nil {
+			return fmt.Errorf("cannot remove existing cached path %v: %w", newdir, err)
+		}
+	}
+
+	rootInfo, err := os.Lstat(olddir)
+	if err != nil {
+		return fmt.Errorf("cannot stat olddir %v: %w", olddir, err)
+	}
+
+	err = os.MkdirAll(newdir, rootInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("cannot create new root dir %v: %w", olddir, err)
+	}
+
+	fastwalkConf := fastwalk.DefaultConfig.Copy()
+	fastwalkConf.Sort = fastwalk.SortDirsFirst
+
+	return fastwalk.Walk(fastwalkConf, olddir, func(oldpath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to walk dir: %v, %w", oldpath, err)
+		}
+
+		newpath := filepath.Join(newdir, strings.TrimPrefix(oldpath, olddir))
+
+		// The new "root" already exists so don't recreate it
+		if newpath == newdir {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("unable to get info for %v: %w", oldpath, err)
+		}
+
+		if d.IsDir() {
+			err = os.Mkdir(newpath, info.Mode())
+			if err != nil {
+				return fmt.Errorf("cannot create dir %v: %w", newpath, err)
+			}
+			return nil
+		}
+
+		// For regular files, use reflink
+		if info.Mode().IsRegular() {
+			err = reflinkFile(oldpath, newpath)
+			if err != nil {
+				return fmt.Errorf("reflink %v to %v: %w", oldpath, newpath, err)
+			}
+		} else {
+			// For symlinks and other types, just copy the file
+			err = copyFile(oldpath, newpath)
+			if err != nil {
+				return fmt.Errorf("copy %v to %v: %w", oldpath, newpath, err)
+			}
+		}
+
+		// Ensure the correct permissions are set
+		err = os.Chmod(newpath, info.Mode())
+		if err != nil {
+			return fmt.Errorf("chmod %v: %w", newpath, err)
+		}
+
+		return nil
+	})
+}
+
+// copyFile copies a file from src to dst, preserving metadata
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
+}
+
+func WriteTar(finalDir string, cacheObjectsDir string, reader *db.TarReader, packPath *string, matcher *FileMatcher, hasReflinkSupport bool) (uint32, uint32, bool, error) {
 	var count uint32
 	var cachedCount uint32
 	dir := finalDir
@@ -279,7 +371,7 @@ func WriteTar(finalDir string, cacheObjectsDir string, reader *db.TarReader, pac
 			fileMatch = false
 		}
 
-		cached, err := writeObject(dir, cacheObjectsDir, reader, header, existingDirs)
+		cached, err := writeObject(dir, cacheObjectsDir, reader, header, existingDirs, hasReflinkSupport)
 		if err != nil {
 			return count, cachedCount, false, err
 		}
@@ -306,4 +398,25 @@ func WriteTar(finalDir string, cacheObjectsDir string, reader *db.TarReader, pac
 	}
 
 	return count, cachedCount, fileMatch, nil
+}
+
+// HasReflinkSupport checks if the given directory supports reflinks.
+// It attempts to create a reflink in the directory and returns true if successful.
+func HasReflinkSupport(dir string) bool {
+	srcFile := filepath.Join(dir, "reflink_test_src")
+	dstFile := filepath.Join(dir, "reflink_test_dst")
+	os.Remove(srcFile)
+	os.Remove(dstFile)
+
+	// Create a test file
+	err := os.WriteFile(srcFile, []byte("test"), 0644)
+	if err != nil {
+		return false
+	}
+	defer os.Remove(srcFile)
+	defer os.Remove(dstFile)
+
+	// Try to create a reflink
+	err = reflinkFile(srcFile, dstFile)
+	return err == nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -455,6 +455,7 @@ func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVe
 
 	workerCount := parallelWorkerCount()
 	span.SetAttributes(key.WorkerCount.Attribute(workerCount))
+	hasReflinkSupport := files.HasReflinkSupport(cacheDir)
 
 	for i := 0; i < workerCount; i++ {
 		// create the attribute here when `i` is different
@@ -477,7 +478,7 @@ func (c *Client) Rebuild(ctx context.Context, project int64, prefix string, toVe
 
 					tarReader.FromBytes(response.Bytes)
 
-					count, cachedCount, match, err := files.WriteTar(dir, CacheObjectsDir(cacheDir), tarReader, response.PackPath, matcher)
+					count, cachedCount, match, err := files.WriteTar(dir, CacheObjectsDir(cacheDir), tarReader, response.PackPath, matcher, hasReflinkSupport)
 					if err != nil {
 						cancel()
 						return err
@@ -883,7 +884,7 @@ func (c *Client) GetCache(ctx context.Context, cacheRootDir string, cacheVersion
 						}
 					}
 
-					count, _, _, err := files.WriteTar(tempDest, CacheObjectsDir(cacheRootDir), tarReader, nil, nil)
+					count, _, _, err := files.WriteTar(tempDest, CacheObjectsDir(cacheRootDir), tarReader, nil, nil, false)
 					if err != nil {
 						cancel()
 						return err

--- a/test/dir_operations_test.go
+++ b/test/dir_operations_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/gadget-inc/dateilager/internal/files"
+	"github.com/stretchr/testify/require"
+)
+
+type dirOperation func(src, dst string) error
+
+func TestDirOperations(t *testing.T) {
+	operations := map[string]dirOperation{
+		"HardlinkDir": files.HardlinkDir,
+	}
+
+	// Only add ReflinkDir to operations if reflinks are supported
+	tmpDir := emptyTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+	if files.HasReflinkSupport(tmpDir) {
+		operations["ReflinkDir"] = files.ReflinkDir
+	}
+
+	for name, op := range operations {
+		t.Run(name, func(t *testing.T) {
+			t.Run("Basic", func(t *testing.T) {
+				tmpDir := emptyTmpDir(t)
+				defer os.RemoveAll(tmpDir)
+
+				// Create source directory with a file
+				srcDir := path.Join(tmpDir, "src")
+				err := os.MkdirAll(srcDir, 0755)
+				require.NoError(t, err, "failed to create source directory")
+				err = os.WriteFile(path.Join(srcDir, "test.txt"), []byte("test content"), 0644)
+				require.NoError(t, err, "failed to create test file")
+
+				// Create destination directory
+				dstDir := path.Join(tmpDir, "dst")
+				err = op(srcDir, dstDir)
+				require.NoError(t, err, "%s failed", name)
+
+				// Verify the directories match
+				err = CompareDirectories(srcDir, dstDir)
+				require.NoError(t, err, "compareDirectories failed")
+
+				// For hardlinks, verify that the files are actually hardlink'd
+				if name == "HardlinkDir" {
+					srcInfo, err := os.Stat(path.Join(srcDir, "test.txt"))
+					require.NoError(t, err, "failed to stat source file")
+					dstInfo, err := os.Stat(path.Join(dstDir, "test.txt"))
+					require.NoError(t, err, "failed to stat destination file")
+					require.Equal(t, srcInfo.Sys(), dstInfo.Sys(), "files should be hardlink'd")
+				}
+			})
+
+			t.Run("WithNestedDirs", func(t *testing.T) {
+				tmpDir := emptyTmpDir(t)
+				defer os.RemoveAll(tmpDir)
+
+				// Create a nested directory structure
+				srcDir := path.Join(tmpDir, "src")
+				err := os.MkdirAll(path.Join(srcDir, "a/b/c"), 0755)
+				require.NoError(t, err, "failed to create nested directories")
+
+				// Create some files in the nested structure
+				files := map[string]string{
+					"a/file1.txt":     "content1",
+					"a/b/file2.txt":   "content2",
+					"a/b/c/file3.txt": "content3",
+				}
+
+				for file, content := range files {
+					err := os.WriteFile(path.Join(srcDir, file), []byte(content), 0644)
+					require.NoError(t, err, "failed to create file %s", file)
+				}
+
+				// Create destination directory
+				dstDir := path.Join(tmpDir, "dst")
+				err = op(srcDir, dstDir)
+				require.NoError(t, err, "%s failed", name)
+
+				// Verify the directories match
+				err = CompareDirectories(srcDir, dstDir)
+				require.NoError(t, err, "compareDirectories failed")
+
+				// For hardlinks, verify that all files are hardlink'd
+				if name == "HardlinkDir" {
+					for file := range files {
+						srcInfo, err := os.Stat(path.Join(srcDir, file))
+						require.NoError(t, err, "failed to stat source file %s", file)
+						dstInfo, err := os.Stat(path.Join(dstDir, file))
+						require.NoError(t, err, "failed to stat destination file %s", file)
+						require.Equal(t, srcInfo.Sys(), dstInfo.Sys(), "files should be hardlink'd: %s", file)
+					}
+				}
+			})
+
+			t.Run("WithExistingDest", func(t *testing.T) {
+				tmpDir := emptyTmpDir(t)
+				defer os.RemoveAll(tmpDir)
+
+				// Create source directory with a file
+				srcDir := path.Join(tmpDir, "src")
+				err := os.MkdirAll(srcDir, 0755)
+				require.NoError(t, err, "failed to create source directory")
+				err = os.WriteFile(path.Join(srcDir, "test.txt"), []byte("test content"), 0644)
+				require.NoError(t, err, "failed to create test file")
+
+				// Create destination directory with existing content
+				dstDir := path.Join(tmpDir, "dst")
+				err = os.MkdirAll(dstDir, 0755)
+				require.NoError(t, err, "failed to create destination directory")
+				err = os.WriteFile(path.Join(dstDir, "existing.txt"), []byte("existing content"), 0644)
+				require.NoError(t, err, "failed to create existing file")
+
+				// Attempt to copy
+				err = op(srcDir, dstDir)
+				require.NoError(t, err, "%s failed", name)
+
+				// Verify the directories match
+				err = CompareDirectories(srcDir, dstDir)
+				require.NoError(t, err, "compareDirectories failed")
+			})
+		})
+	}
+}

--- a/test/hardlink_dir_benchmark_test.go
+++ b/test/hardlink_dir_benchmark_test.go
@@ -38,18 +38,21 @@ func BenchmarkHardlinkDir(b *testing.B) {
 	defer os.RemoveAll(tmpDir)
 
 	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		copyDir := path.Join(tmpDir, "node_modules", fmt.Sprintf("%d", n))
-		err := files.HardlinkDir(bigDir, copyDir)
-		b.StopTimer()
-		if err != nil {
-			b.Error(err)
-		}
 
-		err = CompareDirectories(bigDir, copyDir)
-		if err != nil {
-			b.Error(err)
+	b.Run("hardlink", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			copyDir := path.Join(tmpDir, "node_modules", fmt.Sprintf("%d", n))
+			err := files.HardlinkDir(bigDir, copyDir)
+			b.StopTimer()
+			if err != nil {
+				b.Error(err)
+			}
+
+			err = CompareDirectories(bigDir, copyDir)
+			if err != nil {
+				b.Error(err)
+			}
+			b.StartTimer()
 		}
-		b.StartTimer()
-	}
+	})
 }

--- a/test/reflink_dir_benchmark_test.go
+++ b/test/reflink_dir_benchmark_test.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/gadget-inc/dateilager/internal/files"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReflinkDir(t *testing.T) {
+	// Skip the test if reflinks are not supported
+	tmpDir := emptyTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+	if !files.HasReflinkSupport(tmpDir) {
+		t.Skip("Reflinks are not supported on this filesystem")
+	}
+
+	wd, err := os.Getwd()
+	require.NoError(t, err, "os.Getwd() failed")
+
+	bigDir := path.Join(wd, "../js/node_modules")
+	tmpDir = emptyTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	copyDir := path.Join(tmpDir, "node_modules")
+	err = files.ReflinkDir(bigDir, copyDir)
+	require.NoError(t, err, "ReflinkDir failed")
+
+	err = CompareDirectories(bigDir, copyDir)
+	require.NoError(t, err, "compareDirectories %s vs %s failed", bigDir, tmpDir)
+}
+
+//go:bench
+func BenchmarkReflinkDir(b *testing.B) {
+	// Skip the benchmark if reflinks are not supported
+	tmpDir := emptyTmpDir(b)
+	defer os.RemoveAll(tmpDir)
+	if !files.HasReflinkSupport(tmpDir) {
+		b.Skip("Reflinks are not supported on this filesystem")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		b.Error(err)
+	}
+
+	bigDir := path.Join(wd, "../js/node_modules")
+	tmpDir = emptyTmpDir(b)
+	defer os.RemoveAll(tmpDir)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		copyDir := path.Join(tmpDir, "node_modules", fmt.Sprintf("%d", n))
+		err := files.ReflinkDir(bigDir, copyDir)
+		b.StopTimer()
+		if err != nil {
+			b.Error(err)
+		}
+
+		err = CompareDirectories(bigDir, copyDir)
+		if err != nil {
+			b.Error(err)
+		}
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
This makes dateilager use reflinks for linking to items in the cache if the filesystem has reflink support, which APFS does. We don't currently make use of the cache in local development in Gadget, but I think we should, and this'll make it faster! 

We still need to benchmark in prod if XFS reflinking through the overlay is faster than ext4 hardlinking with copying up -- we know that the raw reflink speed is worse than raw hardlink speed, but I have not actually established that it is worse than hardlink + copy through the overlay. 