### PR TITLE
Simplify prerelease process

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -198,6 +198,35 @@ Then build and push the image:
 make upload-container-image version=0.0.x
 ```
 
+### Pre-release
+
+When you want to test your changes before they've been released - even before they've been merged into `main` - you can create a pre-release.
+
+First, ensure you working directory is clean and the current commit has been pushed.
+
+```bash
+git status
+git push origin HEAD
+```
+
+Then, create a pre-release:
+
+```bash
+make prerelease
+```
+
+This will create a pre-release version named `0.0.0-pre.<git-sha>` and:
+
+1. Build and push the docker image to Gadget's container registry
+2. Tag the current commit with the pre-release version and push the tag to GitHub
+3. Publish the pre-release js package to GitHub
+
+You can then test the pre-release in Gadget's repo using the `update-dateilager.ts` script.
+
+```bash
+development/update-dateilager.ts v0.0.0-pre.<git-sha>
+```
+
 ### Getting PASETO tokens locally
 
 You can sign PASETO tokens locally with this handy online tool: https://token.dev/paseto/. Ensure you use the V2 algorithm in the public mode, and copy the PASTEO public and private key from the `development` folder.

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,7 @@ release: release/migrations.tar.gz
 prerelease: build
 prerelease: build-js
 prerelease:
-ifndef tag
-	$(error tag variable must be set)
-else
-	npx tsx js/dateilager-prerelease.ts -t "$(tag)"
-endif
+	npx tsx js/dateilager-prerelease.ts
 
 prerelease-reset:
 	echo "Resetting js/package.json and default.nix to main, if you have installed packages you want to keep then run with a specific sha"
@@ -315,7 +311,7 @@ build-js: js/dist
 
 k8s:
 	which orb >/dev/null 2>&1; if [ $$? -ne 0 ]; then echo "orb not found"; exit 1; fi
-k8s/start: k8s	
+k8s/start: k8s
 	orb start k8s
 
 k8s/stop: k8s

--- a/js/gitpkg.config.js
+++ b/js/gitpkg.config.js
@@ -2,10 +2,7 @@ const { execSync } = require("child_process");
 
 module.exports = () => ({
   getTagName: (pkg) => {
-    if (!pkg.version.includes("pre")) {
-      console.error(`Version ${pkg.version} does not include 'pre', please use 'make prerelease'`);
-      process.exit(1);
-    }
-    return `${pkg.name}-${pkg.version}-gitpkg`;
+    const sha = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+    return `${pkg.name}-v0.0.0-pre.${sha}-gitpkg`;
   },
 });


### PR DESCRIPTION
This makes our prerelease script simpler by always using `v0.0.0-pre.<git-sha>` for our prerelease tags, not updating the `package.json` and `default.nix`, and not adding another "update version" commit.

We only need to update the `package.json` and `default.nix` when we release real versions.

/cc @Robiathin 