### PR TITLE
make unpublish idempotent

### DIFF
--- a/pkg/api/cached.go
+++ b/pkg/api/cached.go
@@ -33,6 +33,7 @@ const (
 	UPPER_DIR         = "upper"
 	WORK_DIR          = "work"
 	NO_CHANGE_USER    = -1
+	UNMOUNT_SENTINEL  = ".target-path-unmounted"
 )
 
 type Cached struct {
@@ -288,38 +289,59 @@ func (s *Cached) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	upperDir := path.Join(volumePath, UPPER_DIR)
 	workDir := path.Join(volumePath, WORK_DIR)
 
+	// Check if the volume path exists
+	_, err := os.Stat(volumePath)
+	if err != nil && os.IsNotExist(err) {
+		if os.IsNotExist(err) {
+			return &csi.NodeUnpublishVolumeResponse{}, nil // Nothing for us to do
+		}
+		return nil, fmt.Errorf("failed to check volume path %s: %v", volumePath, err)
+	}
+
+	// Check for the unmount sentinel file
+	markerFile := path.Join(targetPath, UNMOUNT_SENTINEL)
+	_, err = os.Stat(markerFile)
+	if err != nil && os.IsNotExist(err) {
+		// Marker file doesn't exist, need to unmount
+		// Unmount the overlay
+		err = execCommand("umount", targetPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmount overlay at %s: %v", targetPath, err)
+		}
+		// Create a marker file to indicate the target path has been unmounted
+		if err := os.WriteFile(markerFile, []byte{}, 0644); err != nil {
+			return nil, fmt.Errorf("failed to create unmount marker file %s: %v", markerFile, err)
+		}
+	}
+
 	// Check if we have anything to clean up
-	_, err := os.Stat(upperDir)
-	if err != nil && os.IsNotExist(err) {
-		return &csi.NodeUnpublishVolumeResponse{}, nil
+	_, err = os.Stat(upperDir)
+	if err != nil && !os.IsNotExist(err) { // If we're not sure about the error then let's still try to clean up
+		// Clean up upper directory from the overlay
+		if os.Getenv("RUN_WITH_SUDO") != "" {
+			err = execCommand("rm", "-rf", upperDir)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove directory %s: %s", upperDir, err)
+			}
+		} else {
+			if err := os.RemoveAll(upperDir); err != nil {
+				return nil, fmt.Errorf("failed to remove directory %s: %s", upperDir, err)
+			}
+		}
 	}
+
 	_, err = os.Stat(workDir)
-	if err != nil && os.IsNotExist(err) {
-		return &csi.NodeUnpublishVolumeResponse{}, nil
-	}
-
-	// Unmount the overlay
-	err = execCommand("umount", targetPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmount overlay at %s: %v", targetPath, err)
-	}
-
-	// Clean up upper and work directories from the overlay
-	if os.Getenv("RUN_WITH_SUDO") != "" {
-		err = execCommand("rm", "-rf", upperDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to remove directory %s: %s", upperDir, err)
-		}
-		err = execCommand("rm", "-rf", workDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to remove directory %s: %s", workDir, err)
-		}
-	} else {
-		if err := os.RemoveAll(upperDir); err != nil {
-			return nil, fmt.Errorf("failed to remove directory %s: %s", upperDir, err)
-		}
-		if err := os.RemoveAll(workDir); err != nil {
-			return nil, fmt.Errorf("failed to remove directory %s: %s", workDir, err)
+	if err != nil && !os.IsNotExist(err) {
+		// Clean up work directory from the overlay
+		if os.Getenv("RUN_WITH_SUDO") != "" {
+			err = execCommand("rm", "-rf", workDir)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove directory %s: %s", workDir, err)
+			}
+		} else {
+			if err := os.RemoveAll(workDir); err != nil {
+				return nil, fmt.Errorf("failed to remove directory %s: %s", workDir, err)
+			}
 		}
 	}
 

--- a/test/cached_csi_test.go
+++ b/test/cached_csi_test.go
@@ -118,6 +118,13 @@ func TestCachedCSIDriverMountsCache(t *testing.T) {
 		TargetPath: targetDir,
 	})
 	require.NoError(t, err)
+
+	// Make sure calling a second time doesn't error
+	_, err = cached.NodeUnpublishVolume(tc.Context(), &csi.NodeUnpublishVolumeRequest{
+		VolumeId:   "foobar",
+		TargetPath: targetDir,
+	})
+	require.NoError(t, err)
 }
 
 func TestCachedCSIDriverMountsCacheAtSuffix(t *testing.T) {


### PR DESCRIPTION
The controller may call `NodeUnpublishVolume` multiple times so we need to make sure that this call is idempotent

