### PR TITLE
Add --driver-name-suffix

### DIFF
--- a/pkg/api/cached.go
+++ b/pkg/api/cached.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	DriverName        = "com.gadget.dateilager.cached"
+	DRIVER_NAME       = "dev.gadget.dateilager.cached"
 	CACHE_PATH_SUFFIX = "dl_cache"
 	UPPER_DIR         = "upper"
 	WORK_DIR          = "work"
@@ -43,10 +43,11 @@ type Cached struct {
 
 	Env environment.Env
 
-	Client      *client.Client
-	StagingPath string
-	CacheUid    int
-	CacheGid    int
+	Client           *client.Client
+	DriverNameSuffix string
+	StagingPath      string
+	CacheUid         int
+	CacheGid         int
 
 	// the current version of the cache on disk
 	currentVersion int64
@@ -111,7 +112,7 @@ func (c *Cached) Prepare(ctx context.Context, cacheVersion int64) error {
 // GetPluginInfo returns metadata of the plugin
 func (c *Cached) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	resp := &csi.GetPluginInfoResponse{
-		Name:          DriverName,
+		Name:          DRIVER_NAME + c.DriverNameSuffix,
 		VendorVersion: version.Version,
 	}
 

--- a/pkg/cachedcli/server.go
+++ b/pkg/cachedcli/server.go
@@ -34,20 +34,21 @@ func NewCacheDaemonCommand() *cobra.Command {
 	)
 
 	var (
-		level        *zapcore.Level
-		encoding     string
-		tracing      bool
-		profilePath  string
-		upstreamHost string
-		upstreamPort uint16
-		healthzPort  uint16
-		timeout      uint
-		headlessHost string
-		stagingPath  string
-		csiSocket    string
-		cacheVersion int64
-		cacheUid     int
-		cacheGid     int
+		level            *zapcore.Level
+		encoding         string
+		tracing          bool
+		profilePath      string
+		upstreamHost     string
+		upstreamPort     uint16
+		healthzPort      uint16
+		timeout          uint
+		headlessHost     string
+		driverNameSuffix string
+		stagingPath      string
+		csiSocket        string
+		cacheVersion     int64
+		cacheUid         int
+		cacheGid         int
 	)
 
 	cmd := &cobra.Command{
@@ -102,11 +103,12 @@ func NewCacheDaemonCommand() *cobra.Command {
 			s := cached.NewServer(ctx)
 
 			cached := &api.Cached{
-				Env:         env,
-				Client:      cl,
-				StagingPath: stagingPath,
-				CacheUid:    cacheUid,
-				CacheGid:    cacheGid,
+				Env:              env,
+				Client:           cl,
+				DriverNameSuffix: driverNameSuffix,
+				StagingPath:      stagingPath,
+				CacheUid:         cacheUid,
+				CacheGid:         cacheGid,
 			}
 
 			logger.Info(ctx, "register Cached")
@@ -182,6 +184,7 @@ func NewCacheDaemonCommand() *cobra.Command {
 	flags.UintVar(&timeout, "timeout", 0, "GRPC client timeout (ms)")
 
 	flags.StringVar(&csiSocket, "csi-socket", "", "path for running the Kubernetes CSI Driver interface")
+	flags.StringVar(&driverNameSuffix, "driver-name-suffix", "", "suffix for the driver name")
 	flags.StringVar(&stagingPath, "staging-path", "", "path for staging downloaded caches")
 	flags.Int64Var(&cacheVersion, "cache-version", -1, "cache version to use")
 	flags.IntVar(&cacheUid, "cache-uid", -1, "uid for cache files")

--- a/test/k8s-local/busy-box-debug.yaml
+++ b/test/k8s-local/busy-box-debug.yaml
@@ -17,7 +17,7 @@ spec:
   volumes:
   - name: gadget
     csi:
-      driver: com.gadget.dateilager.cached
+      driver: dev.gadget.dateilager.cached
       volumeAttributes:
         placeCacheAtPath: "dl_cache"
         mountCache: "true"

--- a/test/k8s-local/cached-csi.yaml
+++ b/test/k8s-local/cached-csi.yaml
@@ -2,7 +2,7 @@
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
-  name: com.gadget.dateilager.cached
+  name: dev.gadget.dateilager.cached
   labels:
     origin: krane
 spec:

--- a/test/k8s-local/cached-daemon.yaml
+++ b/test/k8s-local/cached-daemon.yaml
@@ -61,7 +61,7 @@ spec:
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/com.gadget.dateilager.cached/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/dev.gadget.dateilager.cached/csi.sock"
             - "--health-port=9809"
           volumeMounts:
             - name: plugin-dir
@@ -81,10 +81,9 @@ spec:
         # a working directory for the two containers to share when registering the CSI
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/com.gadget.dateilager.cached
+            path: /var/lib/kubelet/plugins/dev.gadget.dateilager.cached
             type: DirectoryOrCreate
         # the directory for the driver-registrar sidecar container to register our driver with the kubelet
-        #
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/


### PR DESCRIPTION
This adds a `--driver-name-suffix` flag we can pass to the csi-driver to enable blue/green deploys. This also updates our driver name to `dev.gadget.dateilager.cache` instead of `com.gadget.dateilager.cache` since we don't own `gadget.com`.