### PR TITLE
Update fsdiff to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charlievieth/fastwalk v1.0.9
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/dgraph-io/ristretto v0.1.1
-	github.com/gadget-inc/fsdiff v0.4.4
+	github.com/gadget-inc/fsdiff v0.4.5
 	github.com/gobwas/glob v0.2.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jackc/pgx/v5 v5.5.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gadget-inc/fsdiff v0.4.4 h1:hLl/rCcWmW3P27LqMEyT2LVNWDLsREqsncODECH1vNw=
-github.com/gadget-inc/fsdiff v0.4.4/go.mod h1:GJurAL/F4qq4hp7uLc7nhqu9PbszI4/7fkTAUNa/VIY=
+github.com/gadget-inc/fsdiff v0.4.5 h1:33YNF0SLZqLG3YZNuWhjb2ZjWQL2mw7xkR+nnKq5QzU=
+github.com/gadget-inc/fsdiff v0.4.5/go.mod h1:GJurAL/F4qq4hp7uLc7nhqu9PbszI4/7fkTAUNa/VIY=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
fsdiff had a bug where it forgot to close the `.dl/sum.s2` file after writing to it. This update fixes that via this commit:
- https://github.com/gadget-inc/fsdiff/commit/189fc2fae21711560073a6d11b01e4588e6d60ef?w=1

I noticed this while writing LVM tests -- I was failing to unmount a volume because fsdiff was keeping the file open:

![CleanShot 2025-05-22 at 11 47 04@2x](https://github.com/user-attachments/assets/395d8d18-799f-45ff-91bf-dbeba6b8e712)
