### PR TITLE
Add cache to base lv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup LVM devices
         run: |
           sudo truncate -s 5G /var/tmp/lvm-base.img
-          sudo truncate -s 5G /var/tmp/lvm-base-cache.img
+          sudo truncate -s 5G /var/tmp/lvm-read-through-base.img
           sudo truncate -s 5G /var/tmp/lvm-thin1.img
           sudo truncate -s 5G /var/tmp/lvm-thin2.img
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           echo "DL_BASE_LV_FORMAT=${{ matrix.filesystem }}" >> $GITHUB_ENV
           echo "DL_READ_THROUGH_BASE_PV=$read_through_base_device" >> $GITHUB_ENV
           echo "DL_THINPOOL_PV_GLOBS=$thin1_device,$thin2_device" >> $GITHUB_ENV
-          echo "DL_THINPOOL_CACHE_LV_SIZE_KIB=2097152" >> $GITHUB_ENV
+          echo "DL_WRITE_BACK_THINPOOL_PV_SIZE_KIB=2097152" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,13 @@ jobs:
           sudo truncate -s 5G /var/tmp/lvm-thin2.img
 
           base_device=$(sudo losetup --find --show /var/tmp/lvm-base.img)
-          base_cache_device=$(sudo losetup --find --show /var/tmp/lvm-base-cache.img)
+          read_through_base_device=$(sudo losetup --find --show /var/tmp/lvm-read-through-base.img)
           thin1_device=$(sudo losetup --find --show /var/tmp/lvm-thin1.img)
           thin2_device=$(sudo losetup --find --show /var/tmp/lvm-thin2.img)
 
           echo "DL_BASE_PV=$base_device" >> $GITHUB_ENV
           echo "DL_BASE_LV_FORMAT=${{ matrix.filesystem }}" >> $GITHUB_ENV
-          echo "DL_BASE_CACHE_PV=$base_cache_device" >> $GITHUB_ENV
+          echo "DL_READ_THROUGH_BASE_PV=$read_through_base_device" >> $GITHUB_ENV
           echo "DL_THINPOOL_PV_GLOBS=$thin1_device,$thin2_device" >> $GITHUB_ENV
           echo "DL_THINPOOL_CACHE_LV_SIZE_KIB=2097152" >> $GITHUB_ENV
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,18 @@ jobs:
       - name: Setup LVM devices
         run: |
           sudo truncate -s 5G /var/tmp/lvm-base.img
+          sudo truncate -s 5G /var/tmp/lvm-base-cache.img
           sudo truncate -s 5G /var/tmp/lvm-thin1.img
           sudo truncate -s 5G /var/tmp/lvm-thin2.img
 
           base_device=$(sudo losetup --find --show /var/tmp/lvm-base.img)
+          base_cache_device=$(sudo losetup --find --show /var/tmp/lvm-base-cache.img)
           thin1_device=$(sudo losetup --find --show /var/tmp/lvm-thin1.img)
           thin2_device=$(sudo losetup --find --show /var/tmp/lvm-thin2.img)
 
           echo "DL_BASE_PV=$base_device" >> $GITHUB_ENV
           echo "DL_BASE_LV_FORMAT=${{ matrix.filesystem }}" >> $GITHUB_ENV
+          echo "DL_BASE_CACHE_PV=$base_cache_device" >> $GITHUB_ENV
           echo "DL_THINPOOL_PV_GLOBS=$thin1_device,$thin2_device" >> $GITHUB_ENV
           echo "DL_THINPOOL_CACHE_LV_SIZE_KIB=2097152" >> $GITHUB_ENV
 

--- a/pkg/cli/cached-server.go
+++ b/pkg/cli/cached-server.go
@@ -23,17 +23,17 @@ import (
 
 func NewCachedServerCommand() *cobra.Command {
 	var (
-		readThroughBasePV      string
-		baseLVFormat           string
-		basePV                 string
-		cacheGid               int
-		cacheUid               int
-		cacheVersion           int64
-		csiSocket              string
-		healthzPort            uint16
-		nameSuffix             string
-		thinpoolCacheLVSizeKib string
-		thinpoolPVGlobs        string
+		readThroughBasePV          string
+		baseLVFormat               string
+		basePV                     string
+		cacheGid                   int
+		cacheUid                   int
+		cacheVersion               int64
+		csiSocket                  string
+		healthzPort                uint16
+		nameSuffix                 string
+		writeBackThinpoolPVSizeKib string
+		thinpoolPVGlobs            string
 	)
 
 	cmd := &cobra.Command{
@@ -50,7 +50,7 @@ func NewCachedServerCommand() *cobra.Command {
 			cd.BasePV = basePV
 			cd.CacheGid = cacheGid
 			cd.CacheUid = cacheUid
-			cd.ThinpoolCacheLVSizeKib = thinpoolCacheLVSizeKib
+			cd.WriteBackThinpoolPVSizeKib = writeBackThinpoolPVSizeKib
 			cd.ThinpoolPVGlobs = thinpoolPVGlobs
 
 			cachedServer := cached.NewServer(ctx)
@@ -106,7 +106,7 @@ func NewCachedServerCommand() *cobra.Command {
 	flags.StringVar(&basePV, "base-pv", os.Getenv("DL_BASE_PV"), "PV to use for the base LV")
 	flags.StringVar(&csiSocket, "csi-socket", firstNonEmpty(os.Getenv("DL_CSI_SOCKET"), "unix:///csi/csi.sock"), "path for running the Kubernetes CSI Driver interface")
 	flags.StringVar(&nameSuffix, "name-suffix", "", "hyphenated suffix to use for naming the driver and its components")
-	flags.StringVar(&thinpoolCacheLVSizeKib, "thinpool-cache-lv-size-kib", os.Getenv("DL_THINPOOL_CACHE_LV_SIZE_KIB"), "size of the thinpool cache LV in KiB")
+	flags.StringVar(&writeBackThinpoolPVSizeKib, "write-back-thinpool-pv-size-kib", os.Getenv("DL_WRITE_BACK_THINPOOL_PV_SIZE_KIB"), "size of the write back thinpool PV in KiB")
 	flags.StringVar(&thinpoolPVGlobs, "thinpool-pv-globs", os.Getenv("DL_THINPOOL_PV_GLOBS"), "comma-separated globs of PVs to use for the thinpool")
 	flags.Uint16Var(&healthzPort, "healthz-port", 5053, "healthz HTTP port")
 

--- a/pkg/cli/cached-server.go
+++ b/pkg/cli/cached-server.go
@@ -23,6 +23,7 @@ import (
 
 func NewCachedServerCommand() *cobra.Command {
 	var (
+		baseCachePV            string
 		baseLVFormat           string
 		basePV                 string
 		cacheGid               int
@@ -44,6 +45,7 @@ func NewCachedServerCommand() *cobra.Command {
 			ctx := cmd.Context()
 
 			cd := cached.New(client.FromContext(ctx), nameSuffix)
+			cd.BaseCachePV = baseCachePV
 			cd.BaseLVFormat = baseLVFormat
 			cd.BasePV = basePV
 			cd.CacheGid = cacheGid
@@ -99,6 +101,7 @@ func NewCachedServerCommand() *cobra.Command {
 	flags.Int64Var(&cacheVersion, "cache-version", -1, "cache version to prepare")
 	flags.IntVar(&cacheGid, "cache-gid", cached.NO_CHANGE_USER, "gid for cache files")
 	flags.IntVar(&cacheUid, "cache-uid", cached.NO_CHANGE_USER, "uid for cache files")
+	flags.StringVar(&baseCachePV, "base-cache-pv", os.Getenv("DL_BASE_CACHE_PV"), "PV to use for the base cache LV")
 	flags.StringVar(&baseLVFormat, "base-lv-format", firstNonEmpty(os.Getenv("DL_BASE_LV_FORMAT"), cached.EXT4), "filesystem format to use for the base LV")
 	flags.StringVar(&basePV, "base-pv", os.Getenv("DL_BASE_PV"), "PV to use for the base LV")
 	flags.StringVar(&csiSocket, "csi-socket", firstNonEmpty(os.Getenv("DL_CSI_SOCKET"), "unix:///csi/csi.sock"), "path for running the Kubernetes CSI Driver interface")

--- a/pkg/cli/cached-server.go
+++ b/pkg/cli/cached-server.go
@@ -23,7 +23,7 @@ import (
 
 func NewCachedServerCommand() *cobra.Command {
 	var (
-		baseCachePV            string
+		readThroughBasePV      string
 		baseLVFormat           string
 		basePV                 string
 		cacheGid               int
@@ -45,7 +45,7 @@ func NewCachedServerCommand() *cobra.Command {
 			ctx := cmd.Context()
 
 			cd := cached.New(client.FromContext(ctx), nameSuffix)
-			cd.BaseCachePV = baseCachePV
+			cd.ReadThroughBasePV = readThroughBasePV
 			cd.BaseLVFormat = baseLVFormat
 			cd.BasePV = basePV
 			cd.CacheGid = cacheGid
@@ -101,7 +101,7 @@ func NewCachedServerCommand() *cobra.Command {
 	flags.Int64Var(&cacheVersion, "cache-version", -1, "cache version to prepare")
 	flags.IntVar(&cacheGid, "cache-gid", cached.NO_CHANGE_USER, "gid for cache files")
 	flags.IntVar(&cacheUid, "cache-uid", cached.NO_CHANGE_USER, "uid for cache files")
-	flags.StringVar(&baseCachePV, "base-cache-pv", os.Getenv("DL_BASE_CACHE_PV"), "PV to use for the base cache LV")
+	flags.StringVar(&readThroughBasePV, "read-through-base-pv", os.Getenv("DL_READ_THROUGH_BASE_PV"), "PV to use as a read-through cache for the base LV")
 	flags.StringVar(&baseLVFormat, "base-lv-format", firstNonEmpty(os.Getenv("DL_BASE_LV_FORMAT"), cached.EXT4), "filesystem format to use for the base LV")
 	flags.StringVar(&basePV, "base-pv", os.Getenv("DL_BASE_PV"), "PV to use for the base LV")
 	flags.StringVar(&csiSocket, "csi-socket", firstNonEmpty(os.Getenv("DL_CSI_SOCKET"), "unix:///csi/csi.sock"), "path for running the Kubernetes CSI Driver interface")

--- a/test/dir_operations_test.go
+++ b/test/dir_operations_test.go
@@ -301,11 +301,11 @@ func BenchmarkDirOperations(b *testing.B) {
 						baseLVDevice := "/dev/" + baseLV
 						readThroughBasePV := os.Getenv("DL_READ_THROUGH_BASE_PV")
 						thinpoolLV := vg + "/thinpool"
-						thinpoolCacheLVSize := os.Getenv("DL_THINPOOL_CACHE_LV_SIZE_KIB")
-						thinpoolCachePV := "/dev/ram0"
+						writeBackThinpoolPVSizeKIB := os.Getenv("DL_WRITE_BACK_THINPOOL_PV_SIZE_KIB")
+						writeBackThinpoolPV := "/dev/ram0"
 
-						if thinpoolCacheLVSize != "" {
-							defer removePV(b, thinpoolCachePV)
+						if writeBackThinpoolPVSizeKIB != "" {
+							defer removePV(b, writeBackThinpoolPV)
 							defer execRun(b, "modprobe", "-r", "brd")
 						}
 
@@ -347,11 +347,11 @@ func BenchmarkDirOperations(b *testing.B) {
 						ensureLV(b, thinpoolLV, cached.LVCreateThinpoolArgs(vg, thinpoolPVs)...)
 						defer removeLV(b, thinpoolLV)
 
-						if thinpoolCacheLVSize != "" {
-							execRun(b, "modprobe", "brd", "rd_nr=1", "rd_size="+thinpoolCacheLVSize)
-							ensurePV(b, thinpoolCachePV)
-							execRun(b, "vgextend", vg, thinpoolCachePV)
-							execRun(b, "lvconvert", cached.LVConvertThinpoolCacheArgs(thinpoolCachePV, thinpoolLV)...)
+						if writeBackThinpoolPVSizeKIB != "" {
+							execRun(b, "modprobe", "brd", "rd_nr=1", "rd_size="+writeBackThinpoolPVSizeKIB)
+							ensurePV(b, writeBackThinpoolPV)
+							execRun(b, "vgextend", vg, writeBackThinpoolPV)
+							execRun(b, "lvconvert", cached.LVConvertWriteBackThinpoolPVArgs(writeBackThinpoolPV, thinpoolLV)...)
 						}
 
 						execRun(b, "lvchange", "--activate", "n", baseLV)

--- a/test/dir_operations_test.go
+++ b/test/dir_operations_test.go
@@ -299,6 +299,7 @@ func BenchmarkDirOperations(b *testing.B) {
 						vg := "vg_dl_cached_bench"
 						baseLV := vg + "/base"
 						baseLVDevice := "/dev/" + baseLV
+						baseCachePV := os.Getenv("DL_BASE_CACHE_PV")
 						thinpoolLV := vg + "/thinpool"
 						thinpoolCacheLVSize := os.Getenv("DL_THINPOOL_CACHE_LV_SIZE_KIB")
 						thinpoolCachePV := "/dev/ram0"
@@ -334,6 +335,12 @@ func BenchmarkDirOperations(b *testing.B) {
 							execRun(b, "lvchange", "--permission", "r", baseLV)
 							execRun(b, "lvchange", "--activate", "n", baseLV)
 						}()
+
+						if baseCachePV != "" {
+							ensurePV(b, baseCachePV)
+							execRun(b, "vgextend", vg, baseCachePV)
+							execRun(b, "lvconvert", cached.LVConvertBaseCacheArgs(baseCachePV, baseLV)...)
+						}
 
 						execRun(b, "vgextend", append([]string{"--config=devices/allow_mixed_block_sizes=1", vg}, thinpoolPVs...)...)
 

--- a/test/dir_operations_test.go
+++ b/test/dir_operations_test.go
@@ -299,7 +299,7 @@ func BenchmarkDirOperations(b *testing.B) {
 						vg := "vg_dl_cached_bench"
 						baseLV := vg + "/base"
 						baseLVDevice := "/dev/" + baseLV
-						baseCachePV := os.Getenv("DL_BASE_CACHE_PV")
+						readThroughBasePV := os.Getenv("DL_READ_THROUGH_BASE_PV")
 						thinpoolLV := vg + "/thinpool"
 						thinpoolCacheLVSize := os.Getenv("DL_THINPOOL_CACHE_LV_SIZE_KIB")
 						thinpoolCachePV := "/dev/ram0"
@@ -336,10 +336,10 @@ func BenchmarkDirOperations(b *testing.B) {
 							execRun(b, "lvchange", "--activate", "n", baseLV)
 						}()
 
-						if baseCachePV != "" {
-							ensurePV(b, baseCachePV)
-							execRun(b, "vgextend", vg, baseCachePV)
-							execRun(b, "lvconvert", cached.LVConvertBaseCacheArgs(baseCachePV, baseLV)...)
+						if readThroughBasePV != "" {
+							ensurePV(b, readThroughBasePV)
+							execRun(b, "vgextend", vg, readThroughBasePV)
+							execRun(b, "lvconvert", cached.LVConvertReadThroughBasePVArgs(readThroughBasePV, baseLV)...)
 						}
 
 						execRun(b, "vgextend", append([]string{"--config=devices/allow_mixed_block_sizes=1", vg}, thinpoolPVs...)...)


### PR DESCRIPTION
This adds a `--read-through-base-pv` flag to make cached add a read-through cache in-front of the base LV. This should make reads from the base LV faster when the read-through PV has a faster disk than the base PV.

This is what I'm hoping to use this flag for:

**Before**
<img width="2496" height="490" alt="CleanShot 2025-08-20 at 15 02 58@2x" src="https://github.com/user-attachments/assets/bb9d9cbf-02fb-4b91-9f18-458a616bdc83" />

**After**
<img width="2552" height="292" alt="CleanShot 2025-08-20 at 15 03 31@2x" src="https://github.com/user-attachments/assets/ccb7d735-2bba-4667-aa16-5db0df9e9c35" />
