### PR TITLE
Add --read-through-base-pv-chunk-size

### DIFF
--- a/pkg/cli/cached-server.go
+++ b/pkg/cli/cached-server.go
@@ -24,6 +24,7 @@ import (
 func NewCachedServerCommand() *cobra.Command {
 	var (
 		readThroughBasePV          string
+		readThroughBasePVChunkSize string
 		baseLVFormat               string
 		basePV                     string
 		cacheGid                   int
@@ -46,6 +47,7 @@ func NewCachedServerCommand() *cobra.Command {
 
 			cd := cached.New(client.FromContext(ctx), nameSuffix)
 			cd.ReadThroughBasePV = readThroughBasePV
+			cd.ReadThroughBasePVChunkSize = readThroughBasePVChunkSize
 			cd.BaseLVFormat = baseLVFormat
 			cd.BasePV = basePV
 			cd.CacheGid = cacheGid
@@ -101,12 +103,13 @@ func NewCachedServerCommand() *cobra.Command {
 	flags.Int64Var(&cacheVersion, "cache-version", -1, "cache version to prepare")
 	flags.IntVar(&cacheGid, "cache-gid", cached.NO_CHANGE_USER, "gid for cache files")
 	flags.IntVar(&cacheUid, "cache-uid", cached.NO_CHANGE_USER, "uid for cache files")
-	flags.StringVar(&readThroughBasePV, "read-through-base-pv", os.Getenv("DL_READ_THROUGH_BASE_PV"), "PV to use as a read-through cache for the base LV")
 	flags.StringVar(&baseLVFormat, "base-lv-format", firstNonEmpty(os.Getenv("DL_BASE_LV_FORMAT"), cached.EXT4), "filesystem format to use for the base LV")
 	flags.StringVar(&basePV, "base-pv", os.Getenv("DL_BASE_PV"), "PV to use for the base LV")
 	flags.StringVar(&csiSocket, "csi-socket", firstNonEmpty(os.Getenv("DL_CSI_SOCKET"), "unix:///csi/csi.sock"), "path for running the Kubernetes CSI Driver interface")
 	flags.StringVar(&nameSuffix, "name-suffix", "", "hyphenated suffix to use for naming the driver and its components")
 	flags.StringVar(&writeBackThinpoolPVSizeKib, "write-back-thinpool-pv-size-kib", os.Getenv("DL_WRITE_BACK_THINPOOL_PV_SIZE_KIB"), "size of the write back thinpool PV in KiB")
+	flags.StringVar(&readThroughBasePV, "read-through-base-pv", os.Getenv("DL_READ_THROUGH_BASE_PV"), "PV to use as a read-through cache for the base LV")
+	flags.StringVar(&readThroughBasePVChunkSize, "read-through-base-pv-chunk-size", firstNonEmpty(os.Getenv("DL_READ_THROUGH_BASE_PV_CHUNK_SIZE"), "512k"), "chunk size to use for the read-through base PV")
 	flags.StringVar(&thinpoolPVGlobs, "thinpool-pv-globs", os.Getenv("DL_THINPOOL_PV_GLOBS"), "comma-separated globs of PVs to use for the thinpool")
 	flags.Uint16Var(&healthzPort, "healthz-port", 5053, "healthz HTTP port")
 

--- a/test/dir_operations_test.go
+++ b/test/dir_operations_test.go
@@ -337,9 +337,14 @@ func BenchmarkDirOperations(b *testing.B) {
 						}()
 
 						if readThroughBasePV != "" {
+							readThroughBasePVChunkSize := "512k"
+							if chunkSize := os.Getenv("DL_READ_THROUGH_BASE_PV_CHUNK_SIZE"); chunkSize != "" {
+								readThroughBasePVChunkSize = chunkSize
+							}
+
 							ensurePV(b, readThroughBasePV)
 							execRun(b, "vgextend", vg, readThroughBasePV)
-							execRun(b, "lvconvert", cached.LVConvertReadThroughBasePVArgs(readThroughBasePV, baseLV)...)
+							execRun(b, "lvconvert", cached.LVConvertReadThroughBasePVArgs(readThroughBasePV, readThroughBasePVChunkSize, baseLV)...)
 						}
 
 						execRun(b, "vgextend", append([]string{"--config=devices/allow_mixed_block_sizes=1", vg}, thinpoolPVs...)...)


### PR DESCRIPTION
LVM's `allocation/cache_pool_max_chunks` defaults to 1,000,000. This means a cache PV's `--size` / `--chunksize` must be <= 1,000,000.

I hardcoded the read-through base PV's chunk size to 64k in #145 so that it matches the thinpool's LV's `--chunksize`, but this caused the read-through base PV's max size to be ~60GB (`61gib / 64kib = 999,424`).

We plan to use a 375GB ssd as our read-through base PV in production, so this PR adds `--read-through-base-pv-chunk-size` to allow setting a custom `--chunksize`. I also changed the default to `--chunksize` to be 512kb which is what we plan to use for the 375GB ssd in production (`375gib / 512kib = 768,000`).