### PR TITLE
Improve importBasePV idempotency

### DIFF
--- a/test/cached_csi_test.go
+++ b/test/cached_csi_test.go
@@ -397,7 +397,7 @@ func createTestCachedServer(tc util.TestCtx, tmpDir string) (*cached.Cached, str
 		Grpc: grpcServer,
 	}
 
-	cd := cached.New(cl, "test")
+	cd := cached.New(cl, "-test")
 	cd.BaseLVMountPoint = path.Join(tmpDir, "mnt/base")
 	s.RegisterCSI(cd)
 


### PR DESCRIPTION
I'm running into an issue in Gadget's CI where we fail to add the read-through cache to the base PV. This causes cached to crash and restart. When cached restarts, it sees that the base PV has already been imported so it assumes `importBasePV` already completed successfully and early returns, even though cached hasn't created the thinpool yet.

This makes `importBasePV` continue even if the base PV has already been imported so that we can retry adding the read-through cache, thinpool, and write-back cache.

