### PR TITLE
Raise MAX_MESSAGE_SIZE to 400 MB and expose gRPC tuning via env vars

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -2,7 +2,9 @@ package environment
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -50,4 +52,37 @@ func LoadOrProduction() Env {
 		return Prod
 	}
 	return env
+}
+
+// EnvInt reads key from the environment, parses it as an integer, and
+// multiplies by multiplier. Returns (0, false) when the variable is unset,
+// cannot be parsed, or the parsed value is not positive.
+func EnvInt(key string, multiplier int) (int, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n * multiplier, true
+}
+
+// EnvInt32 behaves like EnvInt but additionally guards that the result fits
+// in an int32 before returning.
+func EnvInt32(key string, multiplier int) (int32, bool) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	result := n * multiplier
+	if result > math.MaxInt32 {
+		return 0, false
+	}
+	return int32(result), true
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,7 +37,7 @@ const (
 	BUFFER_SIZE              = 64 * KB
 	INITIAL_WINDOW_SIZE      = 1 * MB
 	INITIAL_CONN_WINDOW_SIZE = 2 * INITIAL_WINDOW_SIZE
-	MAX_MESSAGE_SIZE         = 300 * MB
+	MAX_MESSAGE_SIZE         = 400 * MB
 )
 
 type VersionRange struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,13 +32,39 @@ import (
 )
 
 const (
-	KB                       = 1024
-	MB                       = KB * KB
+	KB = 1024
+	MB = KB * KB
+)
+
+var (
 	BUFFER_SIZE              = 64 * KB
-	INITIAL_WINDOW_SIZE      = 1 * MB
-	INITIAL_CONN_WINDOW_SIZE = 2 * INITIAL_WINDOW_SIZE
+	INITIAL_WINDOW_SIZE      = int32(1 * MB)
+	INITIAL_CONN_WINDOW_SIZE = int32(2 * MB)
 	MAX_MESSAGE_SIZE         = 400 * MB
 )
+
+func init() {
+	if v := os.Getenv("DL_MAX_MESSAGE_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			MAX_MESSAGE_SIZE = n * MB
+		}
+	}
+	if v := os.Getenv("DL_BUFFER_SIZE_KB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			BUFFER_SIZE = n * KB
+		}
+	}
+	if v := os.Getenv("DL_INITIAL_WINDOW_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			INITIAL_WINDOW_SIZE = int32(n * MB)
+		}
+	}
+	if v := os.Getenv("DL_INITIAL_CONN_WINDOW_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			INITIAL_CONN_WINDOW_SIZE = int32(n * MB)
+		}
+	}
+}
 
 type VersionRange struct {
 	From *int64

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gadget-inc/dateilager/internal/db"
+	"github.com/gadget-inc/dateilager/internal/environment"
 	"github.com/gadget-inc/dateilager/internal/files"
 	"github.com/gadget-inc/dateilager/internal/key"
 	"github.com/gadget-inc/dateilager/internal/pb"
@@ -44,25 +45,17 @@ var (
 )
 
 func init() {
-	if v := os.Getenv("DL_MAX_MESSAGE_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			MAX_MESSAGE_SIZE = n * MB
-		}
+	if n, ok := environment.EnvInt("DL_MAX_MESSAGE_SIZE_MB", MB); ok {
+		MAX_MESSAGE_SIZE = n
 	}
-	if v := os.Getenv("DL_BUFFER_SIZE_KB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			BUFFER_SIZE = n * KB
-		}
+	if n, ok := environment.EnvInt("DL_BUFFER_SIZE_KB", KB); ok {
+		BUFFER_SIZE = n
 	}
-	if v := os.Getenv("DL_INITIAL_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			INITIAL_WINDOW_SIZE = int32(n * MB)
-		}
+	if n, ok := environment.EnvInt32("DL_INITIAL_WINDOW_SIZE_MB", MB); ok {
+		INITIAL_WINDOW_SIZE = n
 	}
-	if v := os.Getenv("DL_INITIAL_CONN_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			INITIAL_CONN_WINDOW_SIZE = int32(n * MB)
-		}
+	if n, ok := environment.EnvInt32("DL_INITIAL_CONN_WINDOW_SIZE_MB", MB); ok {
+		INITIAL_CONN_WINDOW_SIZE = n
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,15 +5,14 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"fmt"
-	"math"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gadget-inc/dateilager/internal/auth"
 	"github.com/gadget-inc/dateilager/internal/db"
+	"github.com/gadget-inc/dateilager/internal/environment"
 	"github.com/gadget-inc/dateilager/internal/logger"
 	"github.com/gadget-inc/dateilager/internal/pb"
 	"github.com/gadget-inc/dateilager/internal/telemetry"
@@ -50,30 +49,20 @@ var (
 )
 
 func init() {
-	if v := os.Getenv("DL_MAX_MESSAGE_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			MAX_MESSAGE_SIZE = n * MB
-		}
+	if n, ok := environment.EnvInt("DL_MAX_MESSAGE_SIZE_MB", MB); ok {
+		MAX_MESSAGE_SIZE = n
 	}
-	if v := os.Getenv("DL_BUFFER_SIZE_KB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			BUFFER_SIZE = n * KB
-		}
+	if n, ok := environment.EnvInt("DL_BUFFER_SIZE_KB", KB); ok {
+		BUFFER_SIZE = n
 	}
-	if v := os.Getenv("DL_INITIAL_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n*MB <= math.MaxInt32 {
-			INITIAL_WINDOW_SIZE = int32(n * MB)
-		}
+	if n, ok := environment.EnvInt32("DL_INITIAL_WINDOW_SIZE_MB", MB); ok {
+		INITIAL_WINDOW_SIZE = n
 	}
-	if v := os.Getenv("DL_INITIAL_CONN_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n*MB <= math.MaxInt32 {
-			INITIAL_CONN_WINDOW_SIZE = int32(n * MB)
-		}
+	if n, ok := environment.EnvInt32("DL_INITIAL_CONN_WINDOW_SIZE_MB", MB); ok {
+		INITIAL_CONN_WINDOW_SIZE = n
 	}
-	if v := os.Getenv("DL_MAX_POOL_SIZE"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n <= math.MaxInt32 {
-			MAX_POOL_SIZE = int32(n)
-		}
+	if n, ok := environment.EnvInt32("DL_MAX_POOL_SIZE", 1); ok {
+		MAX_POOL_SIZE = n
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -60,17 +61,17 @@ func init() {
 		}
 	}
 	if v := os.Getenv("DL_INITIAL_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n*MB <= math.MaxInt32 {
 			INITIAL_WINDOW_SIZE = int32(n * MB)
 		}
 	}
 	if v := os.Getenv("DL_INITIAL_CONN_WINDOW_SIZE_MB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n*MB <= math.MaxInt32 {
 			INITIAL_CONN_WINDOW_SIZE = int32(n * MB)
 		}
 	}
 	if v := os.Getenv("DL_MAX_POOL_SIZE"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n <= math.MaxInt32 {
 			MAX_POOL_SIZE = int32(n)
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,7 @@ const (
 	BUFFER_SIZE              = 28 * KB
 	INITIAL_WINDOW_SIZE      = 1 * MB
 	INITIAL_CONN_WINDOW_SIZE = 2 * INITIAL_WINDOW_SIZE
-	MAX_MESSAGE_SIZE         = 300 * MB
+	MAX_MESSAGE_SIZE         = 400 * MB
 	MAX_POOL_SIZE            = 60
 )
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,14 +36,45 @@ import (
 )
 
 const (
-	KB                       = 1024
-	MB                       = KB * KB
-	BUFFER_SIZE              = 28 * KB
-	INITIAL_WINDOW_SIZE      = 1 * MB
-	INITIAL_CONN_WINDOW_SIZE = 2 * INITIAL_WINDOW_SIZE
-	MAX_MESSAGE_SIZE         = 400 * MB
-	MAX_POOL_SIZE            = 60
+	KB = 1024
+	MB = KB * KB
 )
+
+var (
+	BUFFER_SIZE              = 28 * KB
+	INITIAL_WINDOW_SIZE      = int32(1 * MB)
+	INITIAL_CONN_WINDOW_SIZE = int32(2 * MB)
+	MAX_POOL_SIZE            = int32(60)
+	MAX_MESSAGE_SIZE         = 400 * MB
+)
+
+func init() {
+	if v := os.Getenv("DL_MAX_MESSAGE_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			MAX_MESSAGE_SIZE = n * MB
+		}
+	}
+	if v := os.Getenv("DL_BUFFER_SIZE_KB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			BUFFER_SIZE = n * KB
+		}
+	}
+	if v := os.Getenv("DL_INITIAL_WINDOW_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			INITIAL_WINDOW_SIZE = int32(n * MB)
+		}
+	}
+	if v := os.Getenv("DL_INITIAL_CONN_WINDOW_SIZE_MB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			INITIAL_CONN_WINDOW_SIZE = int32(n * MB)
+		}
+	}
+	if v := os.Getenv("DL_MAX_POOL_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			MAX_POOL_SIZE = int32(n)
+		}
+	}
+}
 
 type DbPoolConnector struct {
 	pool       *pgxpool.Pool


### PR DESCRIPTION
A user's `node_modules` directory exceeded the 300 MB gRPC message size cap, causing `dateilager-client` rebuild to fail and leaving their environment perma-crashed. This raises `MAX_MESSAGE_SIZE` to 400 MB on both client and server to unblock them. Related to https://gadget-dev.slack.com/archives/C03FLBPBHFD/p1772482722275909.

As a follow-on, all five gRPC tuning parameters (`MAX_MESSAGE_SIZE`, `BUFFER_SIZE`, `INITIAL_WINDOW_SIZE`, `INITIAL_CONN_WINDOW_SIZE`, and `MAX_POOL_SIZE`) are converted from compile-time constants to package-level vars with `init()` overrides from `DL_*` environment variables, so future adjustments can be made without recompilation.

Two `EnvInt` / `EnvInt32` helpers are added to the `environment` package to centralize the `os.Getenv` + `strconv.Atoi` + overflow-check pattern that would otherwise be duplicated across client and server init functions. The `EnvInt32` variant guards that the result fits in `int32` before casting, addressing the overflow findings flagged by GitHub code scanning.
